### PR TITLE
Ported SQL Backend framework from https://github.com/databrickslabs/ucx

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,6 +2,12 @@ Copyright (2023) Databricks, Inc.
 
 This Software includes software developed at Databricks (https://www.databricks.com/) and its use is subject to the included LICENSE file.
 
+This Software contains code from the following projects, licensed under the Databricks License 2.0:
+
+UCX - https://github.com/databrickslabs/ucx
+Copyright (2023) Databricks, Inc.
+License - https://github.com/databrickslabs/UCX/blob/main/LICENSE
+
 This Software contains code from the following open source projects, licensed under the Apache 2.0 license:
 
 Databricks SDK for Python - https://github.com/databricks/databricks-sdk-py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# databricks-labs-lightsql
+# databricks-labs-lsql
 
 [![PyPI - Version](https://img.shields.io/pypi/v/databricks-labs-lightsql.svg)](https://pypi.org/project/databricks-labs-lightsql)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/databricks-labs-lightsql.svg)](https://pypi.org/project/databricks-labs-lightsql)
@@ -13,7 +13,7 @@ Execute SQL statements in a stateless manner.
 pip install databricks-labs-lsql
 ```
 
-## Usage
+## Executing SQL
 
 Primary use-case of :py:meth:`iterate_rows` and :py:meth:`execute` methods is oriented at executing SQL queries in
 a stateless manner straight away from Databricks SDK for Python, without requiring any external dependencies.
@@ -40,6 +40,19 @@ When you only need to execute the query and have no need to iterate over results
 
     w.statement_execution.execute(warehouse_id, 'CREATE TABLE foo AS SELECT * FROM range(10)')
 
+## Working with dataclasses
+
+This framework allows for mapping with strongly-typed dataclasses between SQL and Python runtime.
+
+It handles the schema creation logic purely from Python datastructure.
+
+## Mocking for unit tests
+
+This includes a lightweight framework to map between dataclass instances and different SQL execution backends:
+- `MockBackend` used for unit testing
+- `RuntimeBackend` used for execution within Databricks Runtime
+- `StatementExecutionBackend` used for reading/writing records purely through REST API
+
 ## Pick the library that you need
 
 _Simple applications_, like AWS Lambdas or Azure Functions, and scripts, that are **constrained by the size of external 
@@ -59,6 +72,9 @@ the stateful [Databricks SQL Connector for Python](https://docs.databricks.com/e
 
 | ...                                     | Databricks Connect 2.x                 | Databricks SQL Connector                          | PyODBC + ODBC Driver                              | Databricks Labs LightSQL           |
 |-----------------------------------------|----------------------------------------|---------------------------------------------------|---------------------------------------------------|------------------------------------|
+ | Light-weight mocking                    | no                                     | no                                                | no                                                | **yes**                            |
+ | Extended support for dataclasses        | limited                                | no                                                | no                                                | **yes**                            |
+ | Strengths                               | almost Databricks Runtime, but locally | works with Python ecosystem                       | works with ODBC ecosystem                         | **tiny**                           |
  | Compressed size                         | 60M                                    | 51M (85%)                                         | 44M (73.3%)                                       | **0.8M (1.3%)**                    |
  | Uncompressed size                       | 312M                                   | 280M (89.7%)                                      | ?                                                 | **30M (9.6%)**                     |
  | Direct dependencies                     | 23                                     | 14                                                | 2                                                 | **1** (Python SDK)                 |
@@ -67,9 +83,8 @@ the stateful [Databricks SQL Connector for Python](https://docs.databricks.com/e
  | Full equivalent of Databricks Runtime   | yes                                    | no                                                | no                                                | **no**                             |
  | Efficient memory usage via Apache Arrow | yes                                    | yes                                               | yes                                               | **no**                             |
  | Connection handling                     | stateful                               | stateful                                          | stateful                                          | **stateless**                      |
- | Strengths                               | almost Databricks Runtime, but locally | works with Python ecosystem                       | works with ODBC ecosystem                         | **tiny** (that's it)               |
  | Official                                | yes                                    | yes                                               | yes                                               | **no**                             |
- | Version checked                         | 2.9.3                                  | 14.0.1                                            | driver v2.7.5                                     | 0.1.0                              |
+ | Version checked                         | 14.0.1                                 | 2.9.3                                             | driver v2.7.5                                     | 0.1.0                              |
 
 ## Project Support
 Please note that all projects in the /databrickslabs github account are provided for your exploration only, and are not formally supported by Databricks with Service Level Agreements (SLAs).  They are provided AS-IS and we do not make any guarantees of any kind.  Please do not submit a support ticket relating to any issues arising from the use of these projects.

--- a/src/databricks/labs/lsql/sql_backend.py
+++ b/src/databricks/labs/lsql/sql_backend.py
@@ -1,0 +1,194 @@
+import dataclasses
+import logging
+import re
+from abc import ABC, abstractmethod
+from typing import Iterator, ClassVar
+
+from databricks.sdk import WorkspaceClient
+
+from databricks.labs.lsql.lib import StatementExecutionExt
+
+logger = logging.getLogger(__name__)
+
+class SqlBackend(ABC):
+    @abstractmethod
+    def execute(self, sql):
+        raise NotImplementedError
+
+    @abstractmethod
+    def fetch(self, sql) -> Iterator[any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_table(self, full_name: str, rows: list[any], klass: type, mode: str = "append"):
+        raise NotImplementedError
+
+    def create_table(self, full_name: str, klass: type):
+        ddl = f"CREATE TABLE IF NOT EXISTS {full_name} ({self._schema_for(klass)}) USING DELTA"
+        self.execute(ddl)
+
+    _builtin_type_mapping: ClassVar[dict[type, str]] = {str: "STRING", int: "INT", bool: "BOOLEAN", float: "FLOAT"}
+
+    @classmethod
+    def _schema_for(cls, klass):
+        fields = []
+        for f in dataclasses.fields(klass):
+            if f.type not in cls._builtin_type_mapping:
+                msg = f"Cannot auto-convert {f.type}"
+                raise SyntaxError(msg)
+            not_null = " NOT NULL"
+            if f.default is None:
+                not_null = ""
+            spark_type = cls._builtin_type_mapping[f.type]
+            fields.append(f"{f.name} {spark_type}{not_null}")
+        return ", ".join(fields)
+
+    @classmethod
+    def _filter_none_rows(cls, rows, full_name):
+        if len(rows) == 0:
+            return rows
+
+        results = []
+        nullable_fields = set()
+
+        for field in dataclasses.fields(rows[0]):
+            if field.default is None:
+                nullable_fields.add(field.name)
+
+        for row in rows:
+            if row is None:
+                continue
+            row_contains_none = False
+            for column, value in dataclasses.asdict(row).items():
+                if value is None and column not in nullable_fields:
+                    logger.warning(f"[{full_name}] Field {column} is None, filtering row")
+                    row_contains_none = True
+                    break
+
+            if not row_contains_none:
+                results.append(row)
+        return results
+
+
+class StatementExecutionBackend(SqlBackend):
+    def __init__(self, ws: WorkspaceClient, warehouse_id, *, max_records_per_batch: int = 1000):
+        self._sql = StatementExecutionExt(ws.api_client)
+        self._warehouse_id = warehouse_id
+        self._max_records_per_batch = max_records_per_batch
+
+    def execute(self, sql):
+        logger.debug(f"[api][execute] {sql}")
+        self._sql.execute(self._warehouse_id, sql)
+
+    def fetch(self, sql) -> Iterator[any]:
+        logger.debug(f"[api][fetch] {sql}")
+        return self._sql.execute_fetch_all(self._warehouse_id, sql)
+
+    def save_table(self, full_name: str, rows: list[any], klass: dataclasses.dataclass, mode="append"):
+        if mode == "overwrite":
+            msg = "Overwrite mode is not yet supported"
+            raise NotImplementedError(msg)
+        rows = self._filter_none_rows(rows, full_name)
+        self.create_table(full_name, klass)
+        if len(rows) == 0:
+            return
+        fields = dataclasses.fields(klass)
+        field_names = [f.name for f in fields]
+        for i in range(0, len(rows), self._max_records_per_batch):
+            batch = rows[i : i + self._max_records_per_batch]
+            vals = "), (".join(self._row_to_sql(r, fields) for r in batch)
+            sql = f'INSERT INTO {full_name} ({", ".join(field_names)}) VALUES ({vals})'
+            self.execute(sql)
+
+    @staticmethod
+    def _row_to_sql(row, fields):
+        data = []
+        for f in fields:
+            value = getattr(row, f.name)
+            if value is None:
+                data.append("NULL")
+            elif f.type == bool:
+                data.append("TRUE" if value else "FALSE")
+            elif f.type == str:
+                value = str(value).replace("'", "''")
+                data.append(f"'{value}'")
+            elif f.type == int:
+                data.append(f"{value}")
+            else:
+                msg = f"unknown type: {f.type}"
+                raise ValueError(msg)
+        return ", ".join(data)
+
+
+class RuntimeBackend(SqlBackend):
+    def __init__(self):
+        from pyspark.sql.session import SparkSession
+
+        if "DATABRICKS_RUNTIME_VERSION" not in os.environ:
+            msg = "Not in the Databricks Runtime"
+            raise RuntimeError(msg)
+
+        self._spark = SparkSession.builder.getOrCreate()
+
+    def execute(self, sql):
+        logger.debug(f"[spark][execute] {sql}")
+        self._spark.sql(sql)
+
+    def fetch(self, sql) -> Iterator[any]:
+        logger.debug(f"[spark][fetch] {sql}")
+        return self._spark.sql(sql).collect()
+
+    def save_table(self, full_name: str, rows: list[any], klass: dataclasses.dataclass, mode: str = "append"):
+        rows = self._filter_none_rows(rows, full_name)
+
+        if len(rows) == 0:
+            self.create_table(full_name, klass)
+            return
+        # pyspark deals well with lists of dataclass instances, as long as schema is provided
+        df = self._spark.createDataFrame(rows, self._schema_for(rows[0]))
+        df.write.saveAsTable(full_name, mode=mode)
+
+class MockBackend(SqlBackend):
+    def __init__(self, *, fails_on_first: dict | None = None, rows: dict | None = None):
+        self._fails_on_first = fails_on_first
+        if not rows:
+            rows = {}
+        self._rows = rows
+        self._save_table = []
+        self.queries = []
+
+    def _sql(self, sql):
+        logger.debug(f"Mock backend.sql() received SQL: {sql}")
+        seen_before = sql in self.queries
+        self.queries.append(sql)
+        if not seen_before and self._fails_on_first is not None:
+            for match, failure in self._fails_on_first.items():
+                if match in sql:
+                    raise RuntimeError(failure)
+
+    def execute(self, sql):
+        self._sql(sql)
+
+    def fetch(self, sql) -> Iterator[any]:
+        self._sql(sql)
+        rows = []
+        if self._rows:
+            for pattern in self._rows.keys():
+                r = re.compile(pattern)
+                if r.match(sql):
+                    logger.debug(f"Found match: {sql}")
+                    rows.extend(self._rows[pattern])
+        logger.debug(f"Returning rows: {rows}")
+        return iter(rows)
+
+    def save_table(self, full_name: str, rows: list[any], klass, mode: str = "append"):
+        if klass.__class__ == type:
+            self._save_table.append((full_name, rows, mode))
+
+    def rows_written_for(self, full_name: str, mode: str) -> list[any]:
+        rows = []
+        for stub_full_name, stub_rows, stub_mode in self._save_table:
+            if not (stub_full_name == full_name and stub_mode == mode):
+                continue
+            rows += stub_rows
+        return rows


### PR DESCRIPTION
This PR adds a lightweight framework to map between dataclass instances and different SQL execution backends:
- `MockBackend` used for unit testing
- `RuntimeBackend` used for execution within Databricks Runtime
- `StatementExecutionBackend` used for reading/writing records purely through REST API