### PR TITLE
Update `_SparkBackend.fetch()` to return iterator instead of list

### DIFF
--- a/src/databricks/labs/lsql/backends.py
+++ b/src/databricks/labs/lsql/backends.py
@@ -200,7 +200,7 @@ class _SparkBackend(SqlBackend):
     def fetch(self, sql: str) -> Iterator[Row]:
         logger.debug(f"[spark][fetch] {self._only_n_bytes(sql, self._debug_truncate_bytes)}")
         try:
-            return self._spark.sql(sql).collect()
+            return iter(self._spark.sql(sql).collect())
         except Exception as e:
             error_message = str(e)
             raise self._api_error_from_message(error_message) from None

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -232,7 +232,7 @@ def test_runtime_backend_fetch():
 
         result = runtime_backend.fetch("SELECT id FROM range(3)")
 
-        assert [Row(id=1), Row(id=2), Row(id=3)] == result
+        assert [Row(id=1), Row(id=2), Row(id=3)] == list(result)
 
         spark.sql.assert_called_with("SELECT id FROM range(3)")
 


### PR DESCRIPTION
`_SparkBackend.fetch()` should return an iterator instead of list.