### PR TITLE
Remove upper bound on `sqlglot` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
   "databricks-labs-blueprint>=0.4.2",
   "databricks-sdk>=0.22.0",
-  "sqlglot>=22.3.1,<22.5.0"
+  "sqlglot>=22.3.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR keeps only the lower bound dependency for `sqlglot`