### PR TITLE
Fix 'Builder' object has no attribute 'sdk_config' error

### DIFF
--- a/src/databricks/labs/lsql/backends.py
+++ b/src/databricks/labs/lsql/backends.py
@@ -239,7 +239,7 @@ class DatabricksConnectBackend(_SparkBackend):
                 DatabricksSession,
             )
 
-            spark = DatabricksSession.builder.sdk_config(ws.config).getOrCreate()
+            spark = DatabricksSession.builder.sdkConfig(ws.config).getOrCreate()
             super().__init__(spark, ws.config.debug_truncate_bytes)
         except ImportError as e:
             raise RuntimeError("Please run `pip install databricks-connect`") from e


### PR DESCRIPTION
Fix 'Builder' object has no attribute 'sdk_config' error.