### PR TITLE
Added more `NotFound` error type

### DIFF
--- a/src/databricks/labs/lsql/core.py
+++ b/src/databricks/labs/lsql/core.py
@@ -448,6 +448,8 @@ class StatementExecutionExt:
             raise NotFound(error_message)
         if "DELTA_TABLE_NOT_FOUND" in error_message:
             raise NotFound(error_message)
+        if "does not exists" in error_message:
+            raise NotFound(error_message)
         if "DELTA_MISSING_TRANSACTION_LOG" in error_message:
             raise DataLoss(error_message)
         mapping = {

--- a/src/databricks/labs/lsql/core.py
+++ b/src/databricks/labs/lsql/core.py
@@ -448,7 +448,7 @@ class StatementExecutionExt:
             raise NotFound(error_message)
         if "DELTA_TABLE_NOT_FOUND" in error_message:
             raise NotFound(error_message)
-        if "does not exists" in error_message:
+        if "does not exist" in error_message:
             raise NotFound(error_message)
         if "DELTA_MISSING_TRANSACTION_LOG" in error_message:
             raise DataLoss(error_message)


### PR DESCRIPTION
Some SQL queries will error with `Database(ucx_shydk,Some(hive_metastore)) does not exist`, `Function(hive_metastore.ucx_slgfw.ucx_tkrq6) does not exist`. We need to classify them as `NotFound` error messages