### PR TITLE
Maintain PySpark compatibility for databricks.labs.lsql.core.Row

### DIFF
--- a/src/databricks/labs/lsql/backends.py
+++ b/src/databricks/labs/lsql/backends.py
@@ -207,6 +207,7 @@ class _SparkBackend(SqlBackend):
                 self._spark.sql(f"USE CATALOG {catalog}")
             if schema:
                 self._spark.sql(f"USE SCHEMA {schema}")
+            # TODO: pyspark.sql.Row is being return instead of databricks.labs.lsql.core.Row
             return iter(self._spark.sql(sql).collect())
         except Exception as e:
             error_message = str(e)

--- a/src/databricks/labs/lsql/backends.py
+++ b/src/databricks/labs/lsql/backends.py
@@ -207,7 +207,7 @@ class _SparkBackend(SqlBackend):
                 self._spark.sql(f"USE CATALOG {catalog}")
             if schema:
                 self._spark.sql(f"USE SCHEMA {schema}")
-            # TODO: pyspark.sql.Row is being return instead of databricks.labs.lsql.core.Row
+            # TODO: pyspark.sql.Row is being returned instead of databricks.labs.lsql.core.Row
             return iter(self._spark.sql(sql).collect())
         except Exception as e:
             error_message = str(e)

--- a/src/databricks/labs/lsql/core.py
+++ b/src/databricks/labs/lsql/core.py
@@ -66,6 +66,10 @@ class Row(tuple):
         """Convert the row to a dictionary with the same conventions as Databricks SDK."""
         return dict(zip(self.__columns__, self, strict=True))
 
+    # PySpark's compatibility
+    def asDict(self, recursive: bool = False) -> dict[str, Any]:
+        return self.as_dict()
+
     def __eq__(self, other):
         """Check if the rows are equal."""
         if not isinstance(other, Row):


### PR DESCRIPTION
Add asDict to databricks.labs.lsql.core.Row to maintain PySpark compatibility