### PR TITLE
 Adjust test with default markdown height `3`

### DIFF
--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -298,7 +298,7 @@ class Tile:
 
 class MarkdownTile(Tile):
     def _default_size(self) -> tuple[int, int]:
-        return _MAXIMUM_DASHBOARD_WIDTH, 2
+        return _MAXIMUM_DASHBOARD_WIDTH, 3
 
 
 class QueryTile(Tile):

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -663,7 +663,7 @@ def test_dashboards_creates_dashboards_where_text_widget_has_expected_width_and_
     position = lakeview_dashboard.pages[0].layout[0].position
 
     assert position.width == 6
-    assert position.height == 2
+    assert position.height == 3
     ws.assert_not_called()
 
 


### PR DESCRIPTION
Fix #178 