### PR TITLE
Extend replace database in query

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -11,11 +11,11 @@ commands:
         description: The folder with dashboard files. By default, the current working directory.
       - name: catalog
         description: |
-          Overwrite the catalog in query with given value. Useful when developing with seperated catalogs, for 
-          example, for production and development.
+          Overwrite the catalog in the queries' `FROM` clauses with given value. 
+          Useful when developing with seperated catalogs, for example, for production and development.
       - name: database
         description: |
-          Overwrite the database in query with given value. Useful when developing with seperated databases, for 
-          example, for production and development.
+          Overwrite the database in the queries' `FROM` clauses with given value. 
+          Useful when developing with seperated databases, for example, for production and development.
       - name: no-open
         description: Do not open the dashboard in the browser after creating

--- a/labs.yml
+++ b/labs.yml
@@ -9,6 +9,10 @@ commands:
     flags:
       - name: folder
         description: The folder with dashboard files. By default, the current working directory.
+      - name: catalog
+        description: |
+          Overwrite the catalog in query with given value. Useful when developing with seperated catalogs, for 
+          example, for production and development.
       - name: database
         description: |
           Overwrite the database in query with given value. Useful when developing with seperated databases, for 

--- a/src/databricks/labs/lsql/cli.py
+++ b/src/databricks/labs/lsql/cli.py
@@ -1,4 +1,3 @@
-import functools
 import webbrowser
 from pathlib import Path
 
@@ -6,8 +5,7 @@ from databricks.labs.blueprint.cli import App
 from databricks.labs.blueprint.entrypoint import get_logger
 from databricks.sdk import WorkspaceClient
 
-from databricks.labs.lsql import dashboards
-from databricks.labs.lsql.dashboards import Dashboards
+from databricks.labs.lsql.dashboards import DashboardMetadata, Dashboards
 
 logger = get_logger(__file__)
 lsql = App(__file__)
@@ -25,10 +23,10 @@ def create_dashboard(
     logger.debug("Creating dashboard ...")
     lakeview_dashboards = Dashboards(w)
     folder = Path(folder)
-    replace_database_in_query = None
+    dashboard_metadata = DashboardMetadata.from_path(folder)
     if database:
-        replace_database_in_query = functools.partial(dashboards.replace_database_in_query, database=database)
-    lakeview_dashboard = lakeview_dashboards.create_dashboard(folder, query_transformer=replace_database_in_query)
+        dashboard_metadata.replace_database(database)
+    lakeview_dashboard = lakeview_dashboards.create_dashboard(dashboard_metadata)
     sdk_dashboard = lakeview_dashboards.deploy_dashboard(lakeview_dashboard)
     if not no_open:
         assert sdk_dashboard.dashboard_id is not None

--- a/src/databricks/labs/lsql/cli.py
+++ b/src/databricks/labs/lsql/cli.py
@@ -25,7 +25,7 @@ def create_dashboard(
     folder = Path(folder)
     dashboard_metadata = DashboardMetadata.from_path(folder)
     if database:
-        dashboard_metadata.replace_database(database)
+        dashboard_metadata = dashboard_metadata.replace_database(database)
     lakeview_dashboard = lakeview_dashboards.create_dashboard(dashboard_metadata)
     sdk_dashboard = lakeview_dashboards.deploy_dashboard(lakeview_dashboard)
     if not no_open:

--- a/src/databricks/labs/lsql/cli.py
+++ b/src/databricks/labs/lsql/cli.py
@@ -16,6 +16,7 @@ def create_dashboard(
     w: WorkspaceClient,
     folder: Path = Path.cwd(),
     *,
+    catalog: str = "",
     database: str = "",
     no_open: bool = False,
 ):
@@ -23,9 +24,9 @@ def create_dashboard(
     logger.debug("Creating dashboard ...")
     lakeview_dashboards = Dashboards(w)
     folder = Path(folder)
-    dashboard_metadata = DashboardMetadata.from_path(folder)
-    if database:
-        dashboard_metadata = dashboard_metadata.replace_database(database)
+    dashboard_metadata = DashboardMetadata.from_path(folder).replace_database(
+        catalog=catalog or None, database=database or None
+    )
     lakeview_dashboard = lakeview_dashboards.create_dashboard(dashboard_metadata)
     sdk_dashboard = lakeview_dashboards.deploy_dashboard(lakeview_dashboard)
     if not no_open:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -355,9 +355,30 @@ class MarkdownTile(Tile):
     _position: Position = Position(0, 0, _MAXIMUM_DASHBOARD_WIDTH, 3)
 
 
-def replace_database_in_query(node: sqlglot.Expression, *, database: str) -> sqlglot.Expression:
-    """Replace the database in a query."""
-    if isinstance(node, sqlglot.exp.Table) and node.args.get("db") is not None:
+def replace_database_in_query(
+    node: sqlglot.Expression,
+    *,
+    database: str,
+    database_to_replace: str | None = None,
+) -> sqlglot.Expression:
+    """Replace the database in a query.
+
+    Parameters :
+        node : sqlglot.Expression
+            The parsed sql query
+        database : str
+            The value to replace the database with
+        database_to_replace : str | None (default: None)
+            The database to replace, if None, all databases are replaced
+
+    Returns :
+        The query with the database replaced
+    """
+    if (
+        isinstance(node, sqlglot.exp.Table)
+        and node.args.get("db") is not None
+        and (database_to_replace is None or getattr(node.args.get("db"), "this", "") == database_to_replace)
+    ):
         node.args["db"].set("this", database)
     return node
 

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -662,7 +662,7 @@ class DashboardMetadata:
         database: str,
         *,
         database_to_replace: str | None = None,
-    ) -> None:
+    ) -> "DashboardMetadata":
         """Replace the database in the queries.
 
         Parameters :
@@ -681,7 +681,7 @@ class DashboardMetadata:
                 node.args["db"].set("this", database)
             return node
 
-        self.query_transformer = replace_database_in_query
+        return dataclasses.replace(self, query_transformer=replace_database_in_query)
 
     def _get_tiles(self) -> list[Tile]:
         """Get the tiles from the tiles metadata.

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -407,7 +407,7 @@ class QueryTile(Tile):
         catalog_to_replace: str | None = None,
         database_to_replace: str | None = None,
     ) -> "QueryTile":
-        """Replace the database in the query.
+        """Replace the catalog and/or database in the query.
 
         Parameters :
             catalog : str

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -659,29 +659,38 @@ class DashboardMetadata:
 
     def replace_database(
         self,
-        database: str,
+        catalog: str | None = None,
+        database: str | None = None,
         *,
+        catalog_to_replace: str | None = None,
         database_to_replace: str | None = None,
     ) -> "DashboardMetadata":
         """Replace the database in the queries.
 
         Parameters :
+            catalog : str
+                The value to replace the catalog with
             database : str
                 The value to replace the database with
+            catalog_to_replace : str | None (default: None)
+                The catalog to replace, if None, all catalogs are replaced
             database_to_replace : str | None (default: None)
                 The database to replace, if None, all databases are replaced
         """
 
-        def replace_database_in_query(node: sqlglot.Expression) -> sqlglot.Expression:
-            if (
-                isinstance(node, sqlglot.exp.Table)
-                and node.args.get("db") is not None
-                and (database_to_replace is None or getattr(node.args.get("db"), "this", "") == database_to_replace)
-            ):
-                node.args["db"].set("this", database)
+        def replace_catalog_and_database_in_query(node: sqlglot.Expression) -> sqlglot.Expression:
+            if isinstance(node, sqlglot.exp.Table):
+                if node.args.get("catalog") is not None and (
+                    catalog_to_replace is None or getattr(node.args.get("catalog"), "this", "") == catalog_to_replace
+                ):
+                    node.args["catalog"].set("this", catalog)
+                if node.args.get("db") is not None and (
+                    database_to_replace is None or getattr(node.args.get("db"), "this", "") == database_to_replace
+                ):
+                    node.args["db"].set("this", database)
             return node
 
-        return dataclasses.replace(self, query_transformer=replace_database_in_query)
+        return dataclasses.replace(self, query_transformer=replace_catalog_and_database_in_query)
 
     def _get_tiles(self) -> list[Tile]:
         """Get the tiles from the tiles metadata.

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -730,6 +730,7 @@ class DashboardMetadata:
                 logger.warning(f"Parsing invalid tile metadata in dashboard.yml: tiles.{tile_id}.{tile_raw}")
                 continue
             tile_metadata = TileMetadata(id=tile_id)
+            # The loop below allows for partial parsing by skipping unsupported fields
             for tile_key, tile_value in tile_raw.items():
                 if tile_key == "id":
                     logger.warning(f"Parsing unsupported field in dashboard.yml: tiles.{tile_id}.id")

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -597,20 +597,11 @@ class CounterTile(QueryTile):
 
 @dataclass
 class DashboardMetadata:
-    """The metadata defining a lakeview dashboard
+    """The metadata defining a lakeview dashboard"""
 
-    Attributes :
-        display_name : str
-            The dashboard display name
-        tile_metadatas : list[TileMetadata] (default: [])
-            The tile metadata objects
-        query_transformer : Callable[[sqlglot.Expression], sqlglot.Expression] | None (default: None)
-            A sqlglot transformer applied on the queries (SQL files) before creating the tiles. If None, no
-            transformation is applied.
-    """
-
-    display_name: str
-    tile_metadatas: list[TileMetadata] = dataclasses.field(default_factory=list)
+    display_name: str  # The dashboard display name
+    tile_metadatas: list[TileMetadata] = dataclasses.field(default_factory=list)  # The tile metadata objects
+    # A sqlglot transformer applied on the queries before creating the tiles. If None, no transformation is applied
     query_transformer: Callable[[sqlglot.Expression], sqlglot.Expression] | None = None
 
     def validate(self) -> None:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -303,9 +303,16 @@ class Tile:
     """A dashboard tile."""
 
     metadata: TileMetadata
-    content: str = ""
 
+    _content: str = ""
     _position: Position = Position(0, 0, 0, 0)
+
+    @property
+    def content(self) -> str:
+        if len(self._content) == 0:
+            _, content = self.metadata.handler.split()
+            self._content = content
+        return self._content
 
     @property
     def position(self) -> Position:
@@ -337,16 +344,15 @@ class Tile:
     @classmethod
     def from_tile_metadata(cls, tile_metadata: TileMetadata) -> "Tile":
         """Create a tile given the tile metadata."""
-        _, content = tile_metadata.handler.split()
         if tile_metadata.is_markdown():
-            return MarkdownTile(tile_metadata, content)
-        query_tile = QueryTile(tile_metadata, content)
+            return MarkdownTile(tile_metadata)
+        query_tile = QueryTile(tile_metadata)
         spec_type = query_tile.infer_spec_type()
         if spec_type is None:
-            return MarkdownTile(tile_metadata, content)
+            return MarkdownTile(tile_metadata)
         if spec_type == CounterSpec:
-            return CounterTile(tile_metadata, content)
-        return TableTile(tile_metadata, content)
+            return CounterTile(tile_metadata)
+        return TableTile(tile_metadata)
 
     def __repr__(self):
         return f"Tile<{self.metadata.id}>"

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -665,7 +665,7 @@ class DashboardMetadata:
             ValueError : If the dashboard metadata is invalid.
         """
         tile_ids = []
-        for tile in self._tiles:
+        for tile in self.tiles:
             if len(tile.content) == 0:
                 raise ValueError(f"Tile has empty content: {tile}")
             tile_ids.append(tile.metadata.id)

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1,4 +1,3 @@
-import functools
 import itertools
 import json
 import logging
@@ -21,7 +20,6 @@ from databricks.labs.lsql.dashboards import (
     Tile,
     TileMetadata,
     WidgetType,
-    replace_database_in_query,
 )
 from databricks.labs.lsql.lakeview import (
     CounterEncodingMap,
@@ -500,8 +498,8 @@ def test_tile_places_tile_below():
 
 def test_dashboards_saves_sql_files_to_folder(tmp_path):
     ws = create_autospec(WorkspaceClient)
-    queries = Path(__file__).parent / "queries"
-    dashboard = Dashboards(ws).create_dashboard(queries)
+    dashboard_metadata = DashboardMetadata.from_path(Path(__file__).parent / "queries")
+    dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     Dashboards(ws).save_to_folder(dashboard, tmp_path)
 
@@ -511,8 +509,8 @@ def test_dashboards_saves_sql_files_to_folder(tmp_path):
 
 def test_dashboards_saves_yml_files_to_folder(tmp_path):
     ws = create_autospec(WorkspaceClient)
-    queries = Path(__file__).parent / "queries"
-    dashboard = Dashboards(ws).create_dashboard(queries)
+    dashboard_metadata = DashboardMetadata.from_path(Path(__file__).parent / "queries")
+    dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     Dashboards(ws).save_to_folder(dashboard, tmp_path)
 
@@ -522,18 +520,19 @@ def test_dashboards_saves_yml_files_to_folder(tmp_path):
 
 def test_dashboards_creates_dashboard_with_first_page_name_after_folder():
     ws = create_autospec(WorkspaceClient)
-    queries = Path(__file__).parent / "queries"
-    lakeview_dashboard = Dashboards(ws).create_dashboard(queries)
+    dashboard_metadata = DashboardMetadata.from_path(Path(__file__).parent / "queries")
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
     page = lakeview_dashboard.pages[0]
     assert page.name == "queries"
     assert page.display_name == "queries"
 
 
 def test_dashboards_creates_dashboard_with_custom_first_page_name(tmp_path):
-    (tmp_path / "dashboard.yml").write_text("display_name: Custom")
-
     ws = create_autospec(WorkspaceClient)
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+
+    (tmp_path / "dashboard.yml").write_text("display_name: Custom")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     page = lakeview_dashboard.pages[0]
     assert page.name == "Custom"
@@ -542,35 +541,38 @@ def test_dashboards_creates_dashboard_with_custom_first_page_name(tmp_path):
 
 @pytest.mark.parametrize("dashboard_content", ["missing_display_name: true", "invalid:\nyml"])
 def test_dashboards_handles_invalid_dashboard_yml(tmp_path, dashboard_content):
+    ws = create_autospec(WorkspaceClient)
+
     queries_path = tmp_path / "queries"
     queries_path.mkdir()
     (queries_path / "dashboard.yml").write_text(dashboard_content)
+    dashboard_metadata = DashboardMetadata.from_path(queries_path)
 
-    ws = create_autospec(WorkspaceClient)
-    lakeview_dashboard = Dashboards(ws).create_dashboard(queries_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     page = lakeview_dashboard.pages[0]
     assert page.name == "queries"
     assert page.display_name == "queries"
+    ws.assert_not_called()
 
 
 def test_dashboards_creates_one_dataset_per_query():
     ws = create_autospec(WorkspaceClient)
     queries = Path(__file__).parent / "queries"
-    dashboard = Dashboards(ws).create_dashboard(queries)
+    dashboard_metadata = DashboardMetadata.from_path(queries)
+    dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
     assert len(dashboard.datasets) == len([query for query in queries.glob("*.sql")])
 
 
 def test_dashboard_creates_datasets_using_query(tmp_path):
     ws = create_autospec(WorkspaceClient)
-
     query = "SELECT count FROM database.table"
     (tmp_path / "counter.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     dataset = lakeview_dashboard.datasets[0]
-
     assert dataset.query == query
     ws.assert_not_called()
 
@@ -588,8 +590,9 @@ SELECT COALESCE(CONCAT(ROUND(SUM(ready) / COUNT(*) * 100, 1), '%'), 'N/A') AS re
 """.lstrip()
     (tmp_path / "counter.sql").write_text(query)
 
-    query_transformer = functools.partial(replace_database_in_query, database="development")
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path, query_transformer=query_transformer)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
+    dashboard_metadata.replace_database("development")
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     dataset = lakeview_dashboard.datasets[0]
 
@@ -602,7 +605,9 @@ SELECT COALESCE(CONCAT(ROUND(SUM(ready) / COUNT(*) * 100, 1), '%'), 'N/A') AS re
 def test_dashboards_creates_one_counter_widget_per_query():
     ws = create_autospec(WorkspaceClient)
     queries = Path(__file__).parent / "queries"
-    dashboard = Dashboards(ws).create_dashboard(queries)
+    dashboard_metadata = DashboardMetadata.from_path(queries)
+
+    dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     counter_widgets = []
     for page in dashboard.pages:
@@ -618,15 +623,14 @@ def test_dashboards_creates_text_widget_for_invalid_query(tmp_path, caplog):
 
     # Test for the invalid query not to be the first or last query
     for i in range(0, 3, 2):
-        with (tmp_path / f"{i}_counter.sql").open("w") as f:
-            f.write(f"SELECT {i} AS count")
+        (tmp_path / f"{i}_counter.sql").write_text(f"SELECT {i} AS count")
 
     invalid_query = "SELECT COUNT(* AS missing_closing_parenthesis"
-    with (tmp_path / "1_invalid.sql").open("w") as f:
-        f.write(invalid_query)
+    (tmp_path / "1_invalid.sql").write_text(invalid_query)
 
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
     with caplog.at_level(logging.WARNING, logger="databricks.labs.lsql.dashboards"):
-        lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+        lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     markdown_widget = lakeview_dashboard.pages[0].layout[1].widget
     assert markdown_widget.textbox_spec == invalid_query
@@ -635,10 +639,9 @@ def test_dashboards_creates_text_widget_for_invalid_query(tmp_path, caplog):
 
 def test_dashboards_does_not_create_widget_for_yml_file(tmp_path, caplog):
     ws = create_autospec(WorkspaceClient)
-
     (tmp_path / "dashboard.yml").write_text("display_name: Git based dashboard")
-
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
     assert len(lakeview_dashboard.pages[0].layout) == 0
 
 
@@ -741,13 +744,13 @@ def test_query_tile_keeps_original_query(tmp_path):
         ("SELECT count FROM catalog.database.table", "SELECT count FROM catalog.development.table", None),
         ("SELECT database FROM database.table", "SELECT database FROM development.table", None),
         (
-            "SELECT * FROM server.database.table, server.other_database.table",
-            "SELECT * FROM server.development.table, server.development.table",
+            "SELECT a FROM server.database.table, server.other_database.table",
+            "SELECT a FROM server.development.table, server.development.table",
             None,
         ),
         (
-            "SELECT left.* FROM server.database.table AS left JOIN server.other_database.table AS right ON left.id = right.id",
-            "SELECT left.* FROM server.development.table AS left JOIN server.development.table AS right ON left.id = right.id",
+            "SELECT left.a FROM server.database.table AS left JOIN server.other_database.table AS right ON left.id = right.id",
+            "SELECT left.a FROM server.development.table AS left JOIN server.development.table AS right ON left.id = right.id",
             None,
         ),
         (
@@ -758,19 +761,14 @@ def test_query_tile_keeps_original_query(tmp_path):
     ],
 )
 def test_query_tile_creates_database_with_database_overwrite(tmp_path, query, query_transformed, database_to_replace):
-    query_path = tmp_path / "counter.sql"
-    query_path.write_text(query)
+    (tmp_path / "counter.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
+    dashboard_metadata.replace_database("development", database_to_replace=database_to_replace)
 
-    replace_with_development_database = functools.partial(
-        replace_database_in_query,
-        database="development",
-        database_to_replace=database_to_replace,
-    )
-    query_tile = QueryTile(TileMetadata.from_path(query_path), query_transformer=replace_with_development_database)
+    datasets = dashboard_metadata.get_datasets()
 
-    dataset = next(query_tile.get_datasets())
-
-    assert dataset.query == sqlglot.parse_one(query_transformed).sql(pretty=True)
+    assert len(datasets) == 1
+    assert datasets[0].query == sqlglot.parse_one(query_transformed).sql(pretty=True)
 
 
 @pytest.mark.parametrize("width", [5, 8, 13])
@@ -814,11 +812,11 @@ def test_table_tile_becomes_wider_with_more_columns(tmp_path):
 
 
 def test_dashboards_creates_dashboard_with_expected_counter_field_encoding_names(tmp_path):
-    with (tmp_path / "query.sql").open("w") as f:
-        f.write("SELECT 1 AS amount")
-
     ws = create_autospec(WorkspaceClient)
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    (tmp_path / "query.sql").write_text("SELECT 1 AS amount")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
+
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     counter_spec = lakeview_dashboard.pages[0].layout[0].widget.spec
     assert isinstance(counter_spec, CounterSpec)
@@ -837,10 +835,11 @@ def test_dashboards_creates_dashboard_with_expected_counter_field_encoding_names
     ],
 )
 def test_dashboards_infers_query_spec(tmp_path, query, spec_expected):
-    (tmp_path / "query.sql").write_text(query)
-
     ws = create_autospec(WorkspaceClient)
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    (tmp_path / "query.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
+
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     spec = lakeview_dashboard.pages[0].layout[0].widget.spec
     assert isinstance(spec, spec_expected)
@@ -848,11 +847,12 @@ def test_dashboards_infers_query_spec(tmp_path, query, spec_expected):
 
 
 def test_dashboards_overrides_show_empty_title_in_query_header(tmp_path):
+    ws = create_autospec(WorkspaceClient)
     query = '-- --overrides \'{"spec": {"frame": {"showTitle": true}}}\'\nSELECT 102132 AS count'
     (tmp_path / "query.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    ws = create_autospec(WorkspaceClient)
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     frame = lakeview_dashboard.pages[0].layout[0].widget.spec.frame
     assert frame.show_title
@@ -875,8 +875,9 @@ tiles:
     """.strip()
     (tmp_path / "dashboard.yml").write_text(dashboard_content)
     (tmp_path / "query.sql").write_text("SELECT 20")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     frame = lakeview_dashboard.pages[0].layout[0].widget.spec.frame
     assert frame.show_title
@@ -885,10 +886,11 @@ tiles:
 
 
 def test_dashboards_creates_dashboard_with_expected_table_field_encodings(tmp_path):
-    (tmp_path / "query.sql").write_text("select 1 as first, 2 as second")
-
     ws = create_autospec(WorkspaceClient)
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    (tmp_path / "query.sql").write_text("select 1 as first, 2 as second")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
+
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     table_spec = lakeview_dashboard.pages[0].layout[0].widget.spec
     assert isinstance(table_spec, TableV1Spec)
@@ -902,12 +904,12 @@ def test_dashboards_creates_dashboards_with_second_widget_to_the_right_of_the_fi
 
     for i in range(2):
         (tmp_path / f"counter_{i}.sql").write_text(f"SELECT {i} AS count")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     layout = lakeview_dashboard.pages[0].layout
     first_position, second_position = layout[0].position, layout[1].position
-
     assert first_position.x < second_position.x
     assert first_position.y == second_position.y
     ws.assert_not_called()
@@ -916,26 +918,25 @@ def test_dashboards_creates_dashboards_with_second_widget_to_the_right_of_the_fi
 def test_dashboards_creates_dashboard_with_many_widgets_not_on_the_first_row(tmp_path):
     ws = create_autospec(WorkspaceClient)
     for i in range(10):
-        with (tmp_path / f"counter_{i}.sql").open("w") as f:
-            f.write(f"SELECT {i} AS count")
+        (tmp_path / f"counter_{i}.sql").write_text(f"SELECT {i} AS count")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
+
     layout = lakeview_dashboard.pages[0].layout
-
     assert layout[-1].position.y > 0
     ws.assert_not_called()
 
 
 def test_dashboards_creates_dashboard_with_widget_below_text_widget(tmp_path):
     ws = create_autospec(WorkspaceClient)
-    with (tmp_path / "000_counter.md").open("w") as f:
-        f.write("# Description")
-    with (tmp_path / "010_counter.sql").open("w") as f:
-        f.write("SELECT 100 AS count")
+    (tmp_path / "000_counter.md").write_text("# Description")
+    (tmp_path / "010_counter.sql").write_text("SELECT 100 AS count")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
+
     layout = lakeview_dashboard.pages[0].layout
-
     assert len(layout) == 2
     assert layout[0].position.y < layout[1].position.y
     ws.assert_not_called()
@@ -955,9 +956,10 @@ tiles:
     (tmp_path / "counter.md").write_text("# Description")
     (tmp_path / "counter.sql").write_text("SELECT 100 AS count")
     (tmp_path / "header_overwrite.sql").write_text("-- --id counter\nSELECT 100 AS count")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
     with pytest.raises(ValueError) as e:
-        Dashboards(ws).create_dashboard(tmp_path)
+        Dashboards(ws).create_dashboard(dashboard_metadata)
     assert "Duplicate id: counter" in str(e.value)
 
 
@@ -966,12 +968,12 @@ def test_dashboards_creates_dashboards_with_widgets_sorted_alphanumerically(tmp_
     ws = create_autospec(WorkspaceClient)
 
     for query_name in query_names:
-        with (tmp_path / f"{query_name}.sql").open("w") as f:
-            f.write("SELECT 1 AS count")
+        (tmp_path / f"{query_name}.sql").write_text("SELECT 1 AS count")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
+
     widget_names = [layout.widget.name for layout in lakeview_dashboard.pages[0].layout]
-
     assert widget_names == query_names
     ws.assert_not_called()
 
@@ -984,10 +986,11 @@ def test_dashboards_creates_dashboards_with_widgets_order_overwrite(tmp_path):
     (tmp_path / "e.sql").write_text("-- --order 1\nSELECT 1 AS count")
     for query_name in "abcdf":
         (tmp_path / f"{query_name}.sql").write_text("SELECT 1 AS count")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
+
     widget_names = [layout.widget.name for layout in lakeview_dashboard.pages[0].layout]
-
     assert "".join(widget_names) == "abecdf"
     ws.assert_not_called()
 
@@ -1000,10 +1003,11 @@ def test_dashboards_creates_dashboards_with_widgets_order_overwrite_zero(tmp_pat
     (tmp_path / "e.sql").write_text("-- --order 0\nSELECT 1 AS count")
     for query_name in "abcdf":
         (tmp_path / f"{query_name}.sql").write_text("SELECT 1 AS count")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
+
     widget_names = [layout.widget.name for layout in lakeview_dashboard.pages[0].layout]
-
     assert "".join(widget_names) == "aebcdf"
     ws.assert_not_called()
 
@@ -1014,15 +1018,18 @@ def test_dashboards_creates_dashboards_with_widget_ordered_using_id(tmp_path):
     (tmp_path / "z.sql").write_text("-- --id a\nSELECT 1 AS count")  # Should be first because id is 'a'
     for query_name in "bcdef":
         (tmp_path / f"{query_name}.sql").write_text("SELECT 1 AS count")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
+
     widget_names = [layout.widget.name for layout in lakeview_dashboard.pages[0].layout]
-
     assert "".join(widget_names) == "abcdef"
     ws.assert_not_called()
 
 
 def test_dashboards_creates_dashboard_with_widget_order_overwrite_from_dashboard_yaml(tmp_path):
+    ws = create_autospec(WorkspaceClient)
+
     content = """
 display_name: Ordering
 
@@ -1033,9 +1040,9 @@ tiles:
     (tmp_path / "dashboard.yml").write_text(content)
     for query_name in "abcdef":
         (tmp_path / f"{query_name}.sql").write_text("SELECT 1 AS count")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    ws = create_autospec(WorkspaceClient)
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     widget_names = [layout.widget.name for layout in lakeview_dashboard.pages[0].layout]
     assert "".join(widget_names) == "eabcdf"
@@ -1043,6 +1050,8 @@ tiles:
 
 
 def test_dashboards_creates_dashboard_where_widget_order_in_header_takes_precedence(tmp_path):
+    ws = create_autospec(WorkspaceClient)
+
     content = """
 display_name: Ordering
 
@@ -1053,9 +1062,9 @@ tiles:
     (tmp_path / "dashboard.yml").write_text(content)
     for index in range(3):
         (tmp_path / f"query_{index}.sql").write_text(f"-- --order {index}\nSELECT {index} AS count")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    ws = create_autospec(WorkspaceClient)
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     widget_names = [layout.widget.name for layout in lakeview_dashboard.pages[0].layout]
     assert widget_names == ["query_0", "query_1", "query_2"]
@@ -1072,8 +1081,9 @@ tiles:
 def test_dashboards_creates_dashboards_where_widget_has_expected_width_and_height(tmp_path, query, width, height):
     ws = create_autospec(WorkspaceClient)
     (tmp_path / "query.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
     position = lakeview_dashboard.pages[0].layout[0].position
 
     assert position.width == width
@@ -1083,13 +1093,12 @@ def test_dashboards_creates_dashboards_where_widget_has_expected_width_and_heigh
 
 def test_dashboards_creates_dashboards_where_text_widget_has_expected_width_and_height(tmp_path):
     ws = create_autospec(WorkspaceClient)
+    (tmp_path / "description.md").write_text("# Description")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    with (tmp_path / "description.md").open("w") as f:
-        f.write("# Description")
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
     position = lakeview_dashboard.pages[0].layout[0].position
-
     assert position.width == 6
     assert position.height == 3
     ws.assert_not_called()
@@ -1097,14 +1106,13 @@ def test_dashboards_creates_dashboards_where_text_widget_has_expected_width_and_
 
 def test_dashboards_creates_dashboards_where_text_widget_has_expected_text(tmp_path):
     ws = create_autospec(WorkspaceClient)
-
     content = "# Description"
-    with (tmp_path / "description.md").open("w") as f:
-        f.write(content)
+    (tmp_path / "description.md").write_text(content)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
+
     widget = lakeview_dashboard.pages[0].layout[0].widget
-
     assert widget.textbox_spec == content
     ws.assert_not_called()
 
@@ -1119,14 +1127,13 @@ def test_dashboards_creates_dashboards_where_text_widget_has_expected_text(tmp_p
 )
 def test_dashboard_creates_dashboard_with_custom_sized_widget(tmp_path, header):
     ws = create_autospec(WorkspaceClient)
-
     query = f"{header}\nSELECT 82917019218921 AS big_number_needs_big_widget"
-    with (tmp_path / "counter.sql").open("w") as f:
-        f.write(query)
+    (tmp_path / "counter.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
+
     position = lakeview_dashboard.pages[0].layout[0].position
-
     assert position.width == 6
     assert position.height == 3
     ws.assert_not_called()
@@ -1134,11 +1141,11 @@ def test_dashboard_creates_dashboard_with_custom_sized_widget(tmp_path, header):
 
 def test_dashboard_creates_dashboard_with_title(tmp_path):
     ws = create_autospec(WorkspaceClient)
-
     query = "-- --title 'Count me in'\nSELECT 2918"
     (tmp_path / "counter.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     frame = lakeview_dashboard.pages[0].layout[0].widget.spec.frame
     assert frame.title == "Count me in"
@@ -1148,10 +1155,10 @@ def test_dashboard_creates_dashboard_with_title(tmp_path):
 
 def test_dashboard_creates_dashboard_without_title(tmp_path):
     ws = create_autospec(WorkspaceClient)
-
     (tmp_path / "counter.sql").write_text("SELECT 109")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     frame = lakeview_dashboard.pages[0].layout[0].widget.spec.frame
     assert frame.title == ""
@@ -1161,11 +1168,11 @@ def test_dashboard_creates_dashboard_without_title(tmp_path):
 
 def test_dashboard_creates_dashboard_with_description(tmp_path):
     ws = create_autospec(WorkspaceClient)
-
     query = "-- --description 'Only when it counts'\nSELECT 2918"
     (tmp_path / "counter.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     frame = lakeview_dashboard.pages[0].layout[0].widget.spec.frame
     assert frame.description == "Only when it counts"
@@ -1175,10 +1182,10 @@ def test_dashboard_creates_dashboard_with_description(tmp_path):
 
 def test_dashboard_creates_dashboard_without_description(tmp_path):
     ws = create_autospec(WorkspaceClient)
-
     (tmp_path / "counter.sql").write_text("SELECT 190219")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     frame = lakeview_dashboard.pages[0].layout[0].widget.spec.frame
     assert frame.description == ""
@@ -1188,12 +1195,12 @@ def test_dashboard_creates_dashboard_without_description(tmp_path):
 
 def test_dashboard_creates_dashboard_with_filter(tmp_path):
     ws = create_autospec(WorkspaceClient)
-
     filter_column = "City"
     query = f"-- --filter {filter_column}\nSELECT Address, City, Province, Country FROM europe"
     (tmp_path / "table.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     layouts = lakeview_dashboard.pages[0].layout
     assert any(f"filter_{filter_column}" in layout.widget.name for layout in layouts)
@@ -1212,9 +1219,10 @@ def test_dashboard_handles_incorrect_query_header(tmp_path, caplog):
     query = "-- --widh 6 --height 5 \nSELECT 82917019218921 AS big_number_needs_big_widget"
     query_path = tmp_path / "counter.sql"
     query_path.write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
     with caplog.at_level(logging.WARNING, logger="databricks.labs.lsql.dashboards"):
-        lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+        lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     position = lakeview_dashboard.pages[0].layout[0].position
     assert position.width == 1
@@ -1226,9 +1234,10 @@ def test_dashboard_handles_incorrect_query_header(tmp_path, caplog):
 def test_create_dashboard_raises_not_implemented_error_for_select_star(tmp_path):
     ws = create_autospec(WorkspaceClient)
     (tmp_path / "star.sql").write_text("SELECT * FROM table")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
     with pytest.raises(NotImplementedError) as e:
-        Dashboards(ws).create_dashboard(tmp_path)
+        Dashboards(ws).create_dashboard(dashboard_metadata)
 
     assert "star" in str(e)
     ws.assert_not_called()
@@ -1241,8 +1250,9 @@ def test_dashboard_creates_dashboard_based_on_markdown_header(tmp_path):
         (tmp_path / f"{query_name}.sql").write_text("SELECT 1 AS count")
     content = "---\norder: -1\nwidth: 6\nheight: 3\n---\n# Description"
     (tmp_path / "widget.md").write_text(content)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     position = lakeview_dashboard.pages[0].layout[0].position
     assert position.width == 6
@@ -1252,11 +1262,11 @@ def test_dashboard_creates_dashboard_based_on_markdown_header(tmp_path):
 
 def test_dashboard_uses_metadata_above_select_when_query_has_cte(tmp_path):
     ws = create_autospec(WorkspaceClient)
-
     query = "WITH data AS (SELECT 1 AS count)\n" "-- --width 6 --height 6\n" "SELECT count FROM data"
     (tmp_path / "widget.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     position = lakeview_dashboard.pages[0].layout[0].position
     assert position.width == 6
@@ -1266,11 +1276,11 @@ def test_dashboard_uses_metadata_above_select_when_query_has_cte(tmp_path):
 
 def test_dashboard_ignores_first_line_metadata_when_query_has_cte(tmp_path):
     ws = create_autospec(WorkspaceClient)
-
     query = "-- --width 6 --height 6\n" "WITH data AS (SELECT 1 AS count)\n" "SELECT count FROM data"
     (tmp_path / "widget.sql").write_text(query)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    lakeview_dashboard = Dashboards(ws).create_dashboard(tmp_path)
+    lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     position = lakeview_dashboard.pages[0].layout[0].position
     assert position.width != 6

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -590,8 +590,7 @@ SELECT COALESCE(CONCAT(ROUND(SUM(ready) / COUNT(*) * 100, 1), '%'), 'N/A') AS re
 """.lstrip()
     (tmp_path / "counter.sql").write_text(query)
 
-    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
-    dashboard_metadata.replace_database("development")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path).replace_database("development")
     lakeview_dashboard = Dashboards(ws).create_dashboard(dashboard_metadata)
 
     dataset = lakeview_dashboard.datasets[0]
@@ -762,8 +761,9 @@ def test_query_tile_keeps_original_query(tmp_path):
 )
 def test_query_tile_creates_database_with_database_overwrite(tmp_path, query, query_transformed, database_to_replace):
     (tmp_path / "counter.sql").write_text(query)
-    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
-    dashboard_metadata.replace_database("development", database_to_replace=database_to_replace)
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path).replace_database(
+        "development", database_to_replace=database_to_replace
+    )
 
     datasets = dashboard_metadata.get_datasets()
 

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -715,7 +715,7 @@ def test_query_tile_finds_fields(tmp_path, query, names):
     query_file.write_text(query)
 
     tile_metadata = TileMetadata(query_file, 1, 1, 1)
-    tile = QueryTile(tile_metadata)
+    tile = QueryTile.from_tile_metadata(tile_metadata)
 
     fields = tile._find_fields()  # pylint: disable=protected-access
 

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -741,7 +741,7 @@ def test_query_tile_keeps_original_query(tmp_path):
     query_path.write_text(query)
 
     tile_metadata = TileMetadata.from_path(query_path)
-    query_tile = QueryTile(tile_metadata)
+    query_tile = QueryTile.from_tile_metadata(tile_metadata)
 
     dataset = next(query_tile.get_datasets())
 

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -221,11 +221,11 @@ def test_tile_metadata_is_query():
 def test_tile_metadata_merges():
     left = TileMetadata(Path("left.sql"), filters=["a"], width=10, widget_type=WidgetType.TABLE)
     right = TileMetadata(Path("right.sql"), widget_type=WidgetType.COUNTER)
-    left.update(right)
-    assert left.id == "right"
-    assert left.width == 10
-    assert left.filters == ["a"]
-    assert left.widget_type == WidgetType.COUNTER
+    merged = left.merge(right)
+    assert merged.id == "right"
+    assert merged.width == 10
+    assert merged.filters == ["a"]
+    assert merged.widget_type == WidgetType.COUNTER
 
 
 def test_base_handler_parses_empty_header(tmp_path):


### PR DESCRIPTION
Improve the database replacement in query by:
- Making it part of the `DashboardMetadata` class
- Allow specifying which database to replace
- Support replacing catalog
- Allow specifying which catalog to replace

See https://github.com/databrickslabs/ucx/pull/1920/files/fae429e4d73eceebd7259c9bcaa390e6c7aa4395#r1670960522

Partially resolves #212