### PR TITLE
Fix boolean cli flags

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -26,6 +26,6 @@ commands:
           Overwrite the database in the queries' `FROM` clauses with given value. 
           Useful when developing with seperated databases, for example, for production and development.
       - name: publish
-        description: Publish the dashboard after creating
-      - name: no-open
-        description: Do not open the dashboard in the browser after creating
+        description: Publish the dashboard after creating by setting to `yes` or `y`.
+      - name: open-browser
+        description: Open the dashboard in the browser after creating by setting to `yes` or `y`.

--- a/src/databricks/labs/lsql/cli.py
+++ b/src/databricks/labs/lsql/cli.py
@@ -10,6 +10,7 @@ from databricks.labs.lsql.dashboards import DashboardMetadata, Dashboards, Query
 logger = get_logger(__file__)
 lsql = App(__file__)
 
+STRING_AFFIRMATIVES = {"yes", "y", "true", "t", "1"}
 
 @lsql.command
 def create_dashboard(
@@ -18,10 +19,13 @@ def create_dashboard(
     *,
     catalog: str = "",
     database: str = "",
-    publish: bool = False,
-    no_open: bool = False,
+    publish: str = "false",
+    open_browser: str = "false",
 ):
     """Create a dashboard from queries"""
+    publish = publish.lower() in STRING_AFFIRMATIVES
+    open_browser = open_browser.lower() in STRING_AFFIRMATIVES
+
     logger.debug("Creating dashboard ...")
     lakeview_dashboards = Dashboards(w)
     folder = Path(folder)
@@ -30,7 +34,7 @@ def create_dashboard(
         database=database or None,
     )
     sdk_dashboard = lakeview_dashboards.create_dashboard(dashboard_metadata, publish=publish)
-    if not no_open:
+    if open_browser:
         assert sdk_dashboard.dashboard_id is not None
         dashboard_url = lakeview_dashboards.get_url(sdk_dashboard.dashboard_id)
         webbrowser.open(dashboard_url)

--- a/src/databricks/labs/lsql/cli.py
+++ b/src/databricks/labs/lsql/cli.py
@@ -12,6 +12,7 @@ lsql = App(__file__)
 
 STRING_AFFIRMATIVES = {"yes", "y", "true", "t", "1"}
 
+
 @lsql.command
 def create_dashboard(
     w: WorkspaceClient,
@@ -23,8 +24,8 @@ def create_dashboard(
     open_browser: str = "false",
 ):
     """Create a dashboard from queries"""
-    publish = publish.lower() in STRING_AFFIRMATIVES
-    open_browser = open_browser.lower() in STRING_AFFIRMATIVES
+    should_publish = publish.lower() in STRING_AFFIRMATIVES
+    should_open_browser = open_browser.lower() in STRING_AFFIRMATIVES
 
     logger.debug("Creating dashboard ...")
     lakeview_dashboards = Dashboards(w)
@@ -33,8 +34,8 @@ def create_dashboard(
         catalog=catalog or None,
         database=database or None,
     )
-    sdk_dashboard = lakeview_dashboards.create_dashboard(dashboard_metadata, publish=publish)
-    if open_browser:
+    sdk_dashboard = lakeview_dashboards.create_dashboard(dashboard_metadata, publish=should_publish)
+    if should_open_browser:
         assert sdk_dashboard.dashboard_id is not None
         dashboard_url = lakeview_dashboards.get_url(sdk_dashboard.dashboard_id)
         webbrowser.open(dashboard_url)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -10,6 +10,6 @@ def test_cli_create_dashboard_invokes_deploy_dashboard():
     ws = create_autospec(WorkspaceClient)
 
     dashboard_path = Path(__file__).parent / "queries"
-    cli.create_dashboard(ws, dashboard_path, no_open=True)
+    cli.create_dashboard(ws, dashboard_path, open_browser="f")
 
     ws.lakeview.create.assert_called_once()


### PR DESCRIPTION
Fix the boolean cli flags. Purely boolean flags are not supported in the `databricks labs` cli command. Therefore, we simulate flags by confirming with a `y` or `yes`.

- [x] Tested manually