### PR TITLE
Fix replace database when catalog or database is None

### DIFF
--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -492,12 +492,19 @@ class QueryTile(Tile):
 
         def replace_catalog_and_database_in_query(node: sqlglot.Expression) -> sqlglot.Expression:
             if isinstance(node, sqlglot.exp.Table):
-                if node.args.get("catalog") is not None and (
-                    catalog_to_replace is None or getattr(node.args.get("catalog"), "this", "") == catalog_to_replace
+                if (
+                    node.args.get("catalog") is not None
+                    and catalog is not None
+                    and (
+                        catalog_to_replace is None
+                        or getattr(node.args.get("catalog"), "this", "") == catalog_to_replace
+                    )
                 ):
                     node.args["catalog"].set("this", catalog)
-                if node.args.get("db") is not None and (
-                    database_to_replace is None or getattr(node.args.get("db"), "this", "") == database_to_replace
+                if (
+                    node.args.get("db") is not None
+                    and database is not None
+                    and (database_to_replace is None or getattr(node.args.get("db"), "this", "") == database_to_replace)
                 ):
                     node.args["db"].set("this", database)
             return node


### PR DESCRIPTION
The system tables disappeared in ucx dashboards when replacing the palceholder database. This PR resolves that issue

<img width="710" alt="Screenshot 2024-07-24 at 15 05 21" src="https://github.com/user-attachments/assets/3641ba19-96ad-490f-83ce-e857ecb4ebe3">
