### PR TITLE
Fix format breaks widget

### DIFF
--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -317,7 +317,7 @@ class Tile:
     def content(self) -> str:
         if len(self._content) == 0:
             _, content = self.metadata.handler.split()
-            self._content = content
+            self._content = self.format(content)
         return self._content
 
     @property

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -435,7 +435,7 @@ class QueryTile(Tile):
                 The maximum text width to wrap at
         """
         try:
-            parsed_query = sqlglot.parse(content, dialect=self._DIALECT)
+            parsed_query = sqlglot.parse(content, dialect=QueryTile._DIALECT)
         except sqlglot.ParseError:
             return content
         statements = []
@@ -447,7 +447,7 @@ class QueryTile(Tile):
             # see https://sqlglot.com/sqlglot/generator.html#Generator
             statements.append(
                 statement.sql(
-                    dialect=self._DIALECT,
+                    dialect=QueryTile._DIALECT,
                     normalize=True,  # normalize identifiers to lowercase
                     pretty=True,  # format the produced SQL string
                     normalize_functions="upper",  # normalize function names to uppercase

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -166,6 +166,7 @@ class QueryHandler(BaseHandler):
             comments.extend(with_expression.comments or [])
         return comments
 
+
 class MarkdownHandler(BaseHandler):
     """Handle Markdown files."""
 

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -144,7 +144,7 @@ class QueryHandler(BaseHandler):
     def split(self) -> tuple[str, str]:
         """Split the query file header from the contents.
 
-        The optional header is the first comment at the top of the file.
+        The optional header is the first comment at the top of the file or above the first SELECT below the CTEs.
         """
         comments = self._find_comments()
         if len(comments) == 0:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -160,6 +160,7 @@ class QueryHandler(BaseHandler):
             return []
         comments = parsed_query.comments or []
         # The comments might be above a CTE's, for example, after formatting a query
+        # https://github.com/tobymao/sqlglot/issues/3810
         with_expression = parsed_query.find(sqlglot.exp.With)
         if with_expression is not None:
             comments.extend(with_expression.comments or [])

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -435,7 +435,7 @@ class QueryTile(Tile):
                 The maximum text width to wrap at
         """
         try:
-            parsed_query = sqlglot.parse(content, dialect="databricks")
+            parsed_query = sqlglot.parse(content, dialect=self._DIALECT)
         except sqlglot.ParseError:
             return content
         statements = []
@@ -447,7 +447,7 @@ class QueryTile(Tile):
             # see https://sqlglot.com/sqlglot/generator.html#Generator
             statements.append(
                 statement.sql(
-                    dialect="databricks",
+                    dialect=self._DIALECT,
                     normalize=True,  # normalize identifiers to lowercase
                     pretty=True,  # format the produced SQL string
                     normalize_functions="upper",  # normalize function names to uppercase

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -335,6 +335,19 @@ class Tile:
         if len(self.content) == 0:
             raise ValueError(f"Tile has empty content: {self}")
 
+    @staticmethod
+    def format(content: str, max_text_width: int = 120) -> str:
+        """Format the content
+
+        Args:
+            content : str
+                The content to format
+            max_text_width : int
+                The maximum text width to wrap at
+        """
+        _ = max_text_width
+        return content
+
     def get_layouts(self) -> Iterable[Layout]:
         """Get the layout(s) reflecting this tile in the dashboard."""
         widget = Widget(name=self.metadata.id, textbox_spec=self.content)
@@ -412,11 +425,19 @@ class QueryTile(Tile):
             raise ValueError(f"Invalid query content: {self.content}") from e
 
     @staticmethod
-    def format(query: str, max_text_width: int = 120) -> str:
+    def format(content: str, max_text_width: int = 120) -> str:
+        """Format the content
+
+        Args:
+            content : str
+                The content to format
+            max_text_width : int
+                The maximum text width to wrap at
+        """
         try:
-            parsed_query = sqlglot.parse(query, dialect="databricks")
+            parsed_query = sqlglot.parse(content, dialect="databricks")
         except sqlglot.ParseError:
-            return query
+            return content
         statements = []
         for statement in parsed_query:
             if statement is None:
@@ -434,7 +455,7 @@ class QueryTile(Tile):
                 )
             )
         formatted_query = ";\n".join(statements)
-        if "$" in query:
+        if "$" in content:
             # replace ${x} with $x, because we use it in UCX view definitions for now
             formatted_query = re.sub(r"\${(\w+)}", r"$\1", formatted_query)
         return formatted_query

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -325,7 +325,7 @@ class Tile:
     def content(self) -> str:
         if len(self._content) == 0:
             _, content = self.metadata.handler.split()
-            self._content = self.format(content)
+            self._content = content
         return self._content
 
     @property
@@ -342,19 +342,6 @@ class Tile:
         """
         if len(self.content) == 0:
             raise ValueError(f"Tile has empty content: {self}")
-
-    @staticmethod
-    def format(content: str, max_text_width: int = 120) -> str:
-        """Format the content
-
-        Args:
-            content : str
-                The content to format
-            max_text_width : int
-                The maximum text width to wrap at
-        """
-        _ = max_text_width
-        return content
 
     def get_layouts(self) -> Iterable[Layout]:
         """Get the layout(s) reflecting this tile in the dashboard."""
@@ -432,7 +419,7 @@ class QueryTile(Tile):
             raise ValueError(f"Invalid query content: {self.content}") from e
 
     @staticmethod
-    def format(content: str, max_text_width: int = 120) -> str:
+    def format(content: str, *, max_text_width: int = 120) -> str:
         """Format the content
 
         Args:

--- a/tests/integration/test_dashboards.py
+++ b/tests/integration/test_dashboards.py
@@ -7,13 +7,12 @@ from pathlib import Path
 import pytest
 from databricks.labs.blueprint.entrypoint import is_in_debug
 from databricks.sdk.core import DatabricksError
-from databricks.sdk.service.dashboards import Dashboard as SDKDashboard
 from databricks.sdk.service.catalog import SchemaInfo
+from databricks.sdk.service.dashboards import Dashboard as SDKDashboard
 
 from databricks.labs.lsql.backends import StatementExecutionBackend
 from databricks.labs.lsql.dashboards import DashboardMetadata, Dashboards
 from databricks.labs.lsql.lakeview.model import Dashboard
-
 
 logger = logging.getLogger(__name__)
 TEST_JOBS_PURGE_TIMEOUT = dt.timedelta(hours=1, minutes=15)

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -824,7 +824,7 @@ SELECT
   a  /* third comment */
 FROM data
 """.strip(),
-            marks=pytest.mark.skip(reason="Wait for resolution on: https://github.com/tobymao/sqlglot/issues/3810"),
+            marks=pytest.mark.skip(reason="https://github.com/tobymao/sqlglot/issues/3810"),
         ),
     ],
 )

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1358,7 +1358,7 @@ def test_dashboard_metadata_reads_markdown_header(tmp_path):
 
 
 @pytest.mark.parametrize("format", [True, False])
-def test_query_tile_handles_cta(tmp_path, format):
+def test_query_tile_handles_cte(tmp_path, format):
     widget_path = (tmp_path / "widget.sql")
     query = "WITH data AS (SELECT 1 AS count)\n-- --width 6 --height 6\nSELECT count FROM data"
     if format:

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1357,9 +1357,12 @@ def test_dashboard_metadata_reads_markdown_header(tmp_path):
     assert position.height == 3
 
 
-def test_query_tile_handles_cta(tmp_path):
+@pytest.mark.parametrize("format", [True, False])
+def test_query_tile_handles_cta(tmp_path, format):
     widget_path = (tmp_path / "widget.sql")
     query = "WITH data AS (SELECT 1 AS count)\n-- --width 6 --height 6\nSELECT count FROM data"
+    if format:
+        query = QueryTile.format(query)
     widget_path.write_text(query)
     tile_metadata = TileMetadata.from_path(widget_path)
     tile = Tile.from_tile_metadata(tile_metadata)

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1358,7 +1358,7 @@ def test_dashboard_metadata_reads_markdown_header(tmp_path):
 
 
 def test_dashboard_metadata_reads_header_above_select_when_query_has_cte(tmp_path):
-    query = "WITH data AS (SELECT 1 AS count)\n" "-- --width 6 --height 6\n" "SELECT count FROM data"
+    query = "WITH data AS (SELECT 1 AS count)\n-- --width 6 --height 6\nSELECT count FROM data"
     (tmp_path / "widget.sql").write_text(query)
     dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
@@ -1370,7 +1370,7 @@ def test_dashboard_metadata_reads_header_above_select_when_query_has_cte(tmp_pat
 
 
 def test_dashboard_metadata_ignores_first_line_metadata_when_query_has_cte(tmp_path):
-    query = "-- --width 6 --height 6\n" "WITH data AS (SELECT 1 AS count)\n" "SELECT count FROM data"
+    query = "-- --width 6 --height 6\nWITH data AS (SELECT 1 AS count)\nSELECT count FROM data"
     (tmp_path / "widget.sql").write_text(query)
     dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -774,13 +774,13 @@ JOIN hive_metastore.other_database.table AS right
 """.strip(),
         ),
         (
-                """
+            """
 WITH data AS (
   SELECT * FROM hive_metastore.database.table
 )
 SELECT a, b FROM data
 """,
-                """
+            """
 WITH data AS (
   SELECT
     *
@@ -792,8 +792,8 @@ SELECT
 FROM data
 """.strip(),
         ),
-        (
-                """
+        pytest.param(
+            """
 /* first comment */
 WITH data AS (
   SELECT * FROM hive_metastore.database.table
@@ -803,7 +803,7 @@ SELECT
   a  /* third comment */
 FROM data
 """,
-                """
+            """
 /* first comment */
 WITH data AS (
   SELECT
@@ -815,6 +815,7 @@ SELECT
   a  /* third comment */
 FROM data
 """.strip(),
+            marks=pytest.mark.skip(reason="Wait for resolution on: https://github.com/tobymao/sqlglot/issues/3810"),
         ),
     ],
 )

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -342,9 +342,16 @@ def test_query_handler_splits_no_header(tmp_path, query):
     assert content == query
 
 
-def test_query_handler_splits_header(tmp_path):
-    query = "-- --order 10\nSELECT 1"
-
+@pytest.mark.parametrize(
+    "query",
+    [
+        "-- --order 10\nSELECT 1",
+        "WITH data AS (SELECT 1 AS count)\n-- --order 10\nSELECT count FROM data",
+        # Below shows the query after formatting the above query
+        "-- --order 10\nWITH data AS (SELECT 1 AS count)\nSELECT count FROM data",
+    ],
+)
+def test_query_handler_splits_header(tmp_path, query):
     path = tmp_path / "query.sql"
     path.write_text(query)
     handler = QueryHandler(path)

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1366,10 +1366,20 @@ def test_dashboard_metadata_reads_markdown_header(tmp_path):
     assert position.height == 3
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        "WITH data AS (SELECT 1 AS count)\n-- --width 6 --height 6\nSELECT count FROM data",
+        # Next query is the query after formatting the above query
+        "-- --width 6 --height 6\nWITH data AS (SELECT 1 AS count)\nSELECT count FROM data",
+        "-- --width 6 --height 6\n/* another comment */\nWITH data AS (SELECT 1 AS count)\nSELECT count FROM data",
+        "-- --width 6 --height 6 /* another comment */\nWITH data AS (SELECT 1 AS count)\nSELECT count FROM data",
+        "-- --width 6 --height 6\nWITH data AS (\n-- another comment\nSELECT 1 AS count)\nSELECT count FROM data",
+    ]
+)
 @pytest.mark.parametrize("format", [True, False])
-def test_query_tile_handles_cte(tmp_path, format):
+def test_query_tile_handles_cte(tmp_path, query, format):
     widget_path = (tmp_path / "widget.sql")
-    query = "WITH data AS (SELECT 1 AS count)\n-- --width 6 --height 6\nSELECT count FROM data"
     if format:
         query = QueryTile.format(query)
     widget_path.write_text(query)

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -347,8 +347,10 @@ def test_query_handler_splits_no_header(tmp_path, query):
     [
         "-- --order 10\nSELECT 1",
         "WITH data AS (SELECT 1 AS count)\n-- --order 10\nSELECT count FROM data",
-        # Below shows the query after formatting the above query
+        # Next query is the query after formatting the above query
         "-- --order 10\nWITH data AS (SELECT 1 AS count)\nSELECT count FROM data",
+        "-- --order 10\n/* another comment */\nWITH data AS (SELECT 1 AS count)\nSELECT count FROM data",
+        "-- --order 10\nWITH data AS (\n-- another comment\nSELECT 1 AS count)\nSELECT count FROM data",
     ],
 )
 def test_query_handler_splits_header(tmp_path, query):

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1366,11 +1366,11 @@ def test_dashboard_metadata_reads_markdown_header(tmp_path):
         "-- --width 6 --height 6\n/* another comment */\nWITH data AS (SELECT 1 AS count)\nSELECT count FROM data",
         "-- --width 6 --height 6 /* another comment */\nWITH data AS (SELECT 1 AS count)\nSELECT count FROM data",
         "-- --width 6 --height 6\nWITH data AS (\n-- another comment\nSELECT 1 AS count)\nSELECT count FROM data",
-    ]
+    ],
 )
 @pytest.mark.parametrize("format", [True, False])
 def test_query_tile_handles_cte(tmp_path, query, format):
-    widget_path = (tmp_path / "widget.sql")
+    widget_path = tmp_path / "widget.sql"
     if format:
         query = QueryTile.format(query)
     widget_path.write_text(query)

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -745,6 +745,41 @@ def test_query_tile_keeps_original_query(tmp_path):
 
 
 @pytest.mark.parametrize(
+    "query, query_formatted",
+    [
+        (
+            "SELECT count FROM catalog.database.table",
+            """
+SELECT
+  count
+FROM catalog.database.table
+""".strip(),
+        ),
+        (
+            "SELECT a FROM server.database.table JOIN remote_server.other_database.table",
+            """
+SELECT
+  a
+FROM server.database.table, remote_server.other_database.table
+""".strip(),
+        ),
+        (
+            "SELECT left.a FROM hive_metastore.database.table AS left JOIN hive_metastore.other_database.table AS right ON left.id = right.id",
+            """
+SELECT
+  left.a
+FROM hive_metastore.database.table AS left
+JOIN hive_metastore.other_database.table AS right
+  ON left.id = right.id
+""".strip(),
+        ),
+    ],
+)
+def test_query_formats(query, query_formatted):
+    assert QueryTile.format(query) == query_formatted
+
+
+@pytest.mark.parametrize(
     "query, query_transformed, database_to_replace",
     [
         ("SELECT count FROM table", "SELECT count FROM table", None),

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1357,6 +1357,17 @@ def test_dashboard_metadata_reads_markdown_header(tmp_path):
     assert position.height == 3
 
 
+def test_query_tile_handles_cta(tmp_path):
+    widget_path = (tmp_path / "widget.sql")
+    query = "WITH data AS (SELECT 1 AS count)\n-- --width 6 --height 6\nSELECT count FROM data"
+    widget_path.write_text(query)
+    tile_metadata = TileMetadata.from_path(widget_path)
+    tile = Tile.from_tile_metadata(tile_metadata)
+
+    assert tile.position.width == 6
+    assert tile.position.height == 6
+
+
 def test_dashboard_metadata_reads_header_above_select_when_query_has_cte(tmp_path):
     query = "WITH data AS (SELECT 1 AS count)\n-- --width 6 --height 6\nSELECT count FROM data"
     (tmp_path / "widget.sql").write_text(query)

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -589,7 +589,11 @@ def test_dashboard_metadata_creates_one_dataset_per_query():
 
 
 def test_dashboard_metadata_creates_datasets_using_query(tmp_path):
-    query = "SELECT count FROM database.table"
+    query = """
+SELECT
+  count
+FROM database.table
+""".strip()
     (tmp_path / "counter.sql").write_text(query)
     dashboard_metadata = DashboardMetadata.from_path(tmp_path)
     dashboard = dashboard_metadata.as_lakeview()
@@ -732,7 +736,12 @@ def test_query_tile_finds_fields(tmp_path, query, names):
 
 
 def test_query_tile_keeps_original_query(tmp_path):
-    query = "SELECT x, y FROM a JOIN b"
+    query = """
+SELECT
+  x,
+  y
+FROM a, b
+""".strip()
     query_path = tmp_path / "counter.sql"
     query_path.write_text(query)
 

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -773,6 +773,49 @@ JOIN hive_metastore.other_database.table AS right
   ON left.id = right.id
 """.strip(),
         ),
+        (
+                """
+WITH data AS (
+  SELECT * FROM hive_metastore.database.table
+)
+SELECT a, b FROM data
+""",
+                """
+WITH data AS (
+  SELECT
+    *
+  FROM hive_metastore.database.table
+)
+SELECT
+  a,
+  b
+FROM data
+""".strip(),
+        ),
+        (
+                """
+/* first comment */
+WITH data AS (
+  SELECT * FROM hive_metastore.database.table
+)
+/* second comment */
+SELECT 
+  a  /* third comment */
+FROM data
+""",
+                """
+/* first comment */
+WITH data AS (
+  SELECT
+    *
+  FROM hive_metastore.database.table
+)
+/* second comment */
+SELECT
+  a  /* third comment */
+FROM data
+""".strip(),
+        ),
     ],
 )
 def test_query_formats(query, query_formatted):

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1402,18 +1402,6 @@ def test_dashboard_metadata_reads_header_above_select_when_query_has_cte(tmp_pat
     assert position.height == 6
 
 
-def test_dashboard_metadata_ignores_first_line_metadata_when_query_has_cte(tmp_path):
-    query = "-- --width 6 --height 6\nWITH data AS (SELECT 1 AS count)\nSELECT count FROM data"
-    (tmp_path / "widget.sql").write_text(query)
-    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
-
-    dashboard = dashboard_metadata.as_lakeview()
-
-    position = dashboard.pages[0].layout[0].position
-    assert position.width != 6
-    assert position.height != 6
-
-
 def test_dashboards_saves_sql_files_to_folder(tmp_path):
     ws = create_autospec(WorkspaceClient)
     dashboard_metadata = DashboardMetadata.from_path(Path(__file__).parent / "queries")

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -598,11 +598,7 @@ def test_dashboard_metadata_creates_one_dataset_per_query():
 
 
 def test_dashboard_metadata_creates_datasets_using_query(tmp_path):
-    query = """
-SELECT
-  count
-FROM database.table
-""".strip()
+    query = "SELECT count FROM database.table"
     (tmp_path / "counter.sql").write_text(query)
     dashboard_metadata = DashboardMetadata.from_path(tmp_path)
     dashboard = dashboard_metadata.as_lakeview()
@@ -745,12 +741,7 @@ def test_query_tile_finds_fields(tmp_path, query, names):
 
 
 def test_query_tile_keeps_original_query(tmp_path):
-    query = """
-SELECT
-  x,
-  y
-FROM a, b
-""".strip()
+    query = "SELECT x, y FROM a, b"
     query_path = tmp_path / "counter.sql"
     query_path.write_text(query)
 


### PR DESCRIPTION
Formatting of a query might break the widget when it contains a CTA. This PR resolves that

Fixes #234

Dashboard from new integration test screenshot. Note that it contains the title on the tile, showing the changes work:

<img width="1025" alt="Screenshot 2024-07-25 at 10 24 10" src="https://github.com/user-attachments/assets/5d9827c0-4386-40cc-8814-82a4d202e54b">
