### PR TITLE
adding normalize-case option to databricks labs lsql fmt cmd

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -12,6 +12,9 @@ commands:
     flags:
       - name: folder
         description: The folder with SQL files. By default, the current working directory.
+      - name: normalize-case
+        description: If the query text should be normalized to lower case.
+
   - name: create-dashboard
     description: Create an unpublished dashboard from code, see [docs](./docs/dashboards.md).
     flags:

--- a/src/databricks/labs/lsql/cli.py
+++ b/src/databricks/labs/lsql/cli.py
@@ -43,13 +43,13 @@ def create_dashboard(
 
 
 @lsql.command(is_unauthenticated=True)
-def fmt(folder: Path = Path.cwd()):
+def fmt(folder: Path = Path.cwd(), normalize_case: bool = True):
     """Format SQL files in a folder"""
     logger.debug("Formatting SQL files ...")
     folder = Path(folder)
     for sql_file in folder.glob("**/*.sql"):
         sql = sql_file.read_text()
-        formatted_sql = QueryTile.format(sql)
+        formatted_sql = QueryTile.format(sql, normalize_case)
         sql_file.write_text(formatted_sql)
         logger.debug(f"Formatted {sql_file}")
 

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -418,7 +418,7 @@ class QueryTile(Tile):
             raise ValueError(f"Invalid query content: {self.content}") from e
 
     @staticmethod
-    def format(content: str, *, max_text_width: int = 120) -> str:
+    def format(content: str, normalize_case: bool = True, *, max_text_width: int = 120) -> str:
         """Format the content
 
         Args:
@@ -426,6 +426,8 @@ class QueryTile(Tile):
                 The content to format
             max_text_width : int
                 The maximum text width to wrap at
+            normalize_case : bool
+                If the query should be normalized to lower case
         """
         try:
             parsed_query = sqlglot.parse(content, dialect=_SQL_DIALECT)
@@ -441,7 +443,7 @@ class QueryTile(Tile):
             statements.append(
                 statement.sql(
                     dialect=_SQL_DIALECT,
-                    normalize=True,  # normalize identifiers to lowercase
+                    normalize=normalize_case,  # normalize identifiers to lowercase
                     pretty=True,  # format the produced SQL string
                     normalize_functions="upper",  # normalize function names to uppercase
                     max_text_width=max_text_width,  # wrap text at 120 characters

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -832,6 +832,20 @@ def test_query_formats(query, query_formatted):
     assert QueryTile.format(query) == query_formatted
 
 
+def test_query_formats_no_normalize():
+    query = """ select a.request_params.clusterId, 
+    a.request_params.notebookId 
+    from system.access.audit AS a left outer join inventory.clusters AS c
+ON a.request_params.clusterId = c.cluster_id AND a.action_name = 'runCommand'"""
+    query_formatted = """SELECT
+  a.request_params.clusterId,
+  a.request_params.notebookId
+FROM system.access.audit AS a
+LEFT OUTER JOIN inventory.clusters AS c
+  ON a.request_params.clusterId = c.cluster_id AND a.action_name = 'runCommand'"""
+    assert QueryTile.format(query, False) == query_formatted
+
+
 @pytest.mark.parametrize(
     "query, query_transformed, database_to_replace",
     [


### PR DESCRIPTION
databricks labs lsql fmt cmd be defaults normalizes the query to lower case. Some queries are case sensitive
(ex UCX dashboard using map field keys)
This PR adds a parameter normalize-case to the fmt cli cmd to allow user to not normalize the query text (default would be to normalize as before)

Resolves #253 