### PR TITLE
Make hatch a prerequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ clean:
 	rm -fr **/*.pyc
 
 .venv/bin/python:
-	pip install hatch==1.7.0
 	hatch env create
 
 dev: .venv/bin/python


### PR DESCRIPTION
Avoids errors when `pip` command is not recognized