### PR TITLE
add support for exclusions in 'fmt' command

### DIFF
--- a/tests/unit/samples/with-line-comments.sql
+++ b/tests/unit/samples/with-line-comments.sql
@@ -1,0 +1,2 @@
+-- a comment
+SELECT * FROM xyz_table

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,9 +1,13 @@
+import json
+import sys
 from pathlib import Path
+from unittest import mock
 from unittest.mock import create_autospec
 
 from databricks.sdk import WorkspaceClient
 
 from databricks.labs.lsql import cli
+from databricks.labs.lsql.cli import lsql
 
 
 def test_cli_create_dashboard_invokes_deploy_dashboard():
@@ -13,3 +17,15 @@ def test_cli_create_dashboard_invokes_deploy_dashboard():
     cli.create_dashboard(ws, dashboard_path, open_browser="f")
 
     ws.lakeview.create.assert_called_once()
+
+
+def test_cli_fmt_excludes_directories():
+    path = Path(__file__).parent.parent.parent
+    json_command = json.dumps(
+        {
+            "command": "fmt",
+            "flags": {"log_level": "disabled", "folder": path.as_posix(), "exclude": ["tests/unit/samples/"]},
+        }
+    )
+    with mock.patch.object(sys, "argv", [..., json_command]):
+        lsql()


### PR DESCRIPTION
Current implementation does not support exclusions when running 'fmt' command.
This is blocking when verifying notebooks in ucx because the fmt sqlglot converts single line comments `-- comment` into inlined comments `/* comment */ ` thus misleading the verifier.
This PR implements exclusions when running 'fmt' command.
Example cmd line is '`databricks labs lsql fmt --exclude tests/units/samples`'
The added unit test is verified manually.
Fixes #261 