### PR TITLE
Added support for generic types in `SqlBackend`

### DIFF
--- a/tests/integration/test_structs.py
+++ b/tests/integration/test_structs.py
@@ -1,0 +1,36 @@
+import datetime
+from dataclasses import dataclass
+
+from databricks.labs.lsql.backends import StatementExecutionBackend
+
+
+@dataclass
+class Foo:
+    first: str
+    second: bool | None
+
+
+@dataclass
+class Nested:
+    foo: Foo
+    since: datetime.date
+    created: datetime.datetime
+    mapping: dict[str, int]
+    array: list[int]
+
+
+def test_appends_complex_types(ws, env_or_skip, make_random) -> None:
+    sql_backend = StatementExecutionBackend(ws, env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"))
+    today = datetime.date.today()
+    now = datetime.datetime.now()
+    full_name = f"hive_metastore.default.t{make_random(4)}"
+    sql_backend.save_table(
+        full_name,
+        [
+            Nested(Foo("a", True), today, now, {"a": 1, "b": 2}, [1, 2, 3]),
+            Nested(Foo("b", False), today, now, {"c": 3, "d": 4}, [4, 5, 6]),
+        ],
+        Nested,
+    )
+    rows = list(sql_backend.fetch(f"SELECT * FROM {full_name}"))
+    assert len(rows) == 2

--- a/tests/unit/test_structs.py
+++ b/tests/unit/test_structs.py
@@ -36,19 +36,20 @@ class NotDataclass:
         (datetime.date, "DATE"),
         (datetime.datetime, "TIMESTAMP"),
         (list[str], "ARRAY<STRING>"),
+        (set[str], "ARRAY<STRING>"),
         (dict[str, int], "MAP<STRING,LONG>"),
         (dict[int, list[str]], "MAP<LONG,ARRAY<STRING>>"),
         (Foo, "STRUCT<first:STRING,second:BOOLEAN>"),
         (Nested, "STRUCT<foo:STRUCT<first:STRING,second:BOOLEAN>,mapping:MAP<STRING,LONG>,array:ARRAY<LONG>>"),
     ],
 )
-def test_struct_inference(type_ref, ddl):
+def test_struct_inference(type_ref, ddl) -> None:
     inference = StructInference()
     assert inference.as_ddl(type_ref) == ddl
 
 
 @pytest.mark.parametrize("type_ref", [type(None), list, set, tuple, dict, object, NotDataclass])
-def test_struct_inference_raises_on_unknown_type(type_ref):
+def test_struct_inference_raises_on_unknown_type(type_ref) -> None:
     inference = StructInference()
     with pytest.raises(StructInferError):
         inference.as_ddl(type_ref)
@@ -65,6 +66,6 @@ def test_struct_inference_raises_on_unknown_type(type_ref):
         ),
     ],
 )
-def test_as_schema(type_ref, ddl):
+def test_as_schema(type_ref, ddl) -> None:
     inference = StructInference()
     assert inference.as_schema(type_ref) == ddl


### PR DESCRIPTION
This PR adds the ability to use rich dataclasses like:

```python
@dataclass
class Foo:
    first: str
    second: bool | None

@dataclass
class Nested:
    foo: Foo
    mapping: dict[str, int]
    array: list[int]
```