### PR TITLE
Set catalog on `SchemaDeployer` to overwrite the default `hive_metastore`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "coverage[toml]>=6.5",
     "pytest",
     "pylint",
+    "databricks-labs-pytester>=0.2.1",
     "pytest-xdist",
     "pytest-cov>=4.0.0,<5.0.0",
     "pytest-mock>=3.0.0,<4.0.0",

--- a/src/databricks/labs/lsql/core.py
+++ b/src/databricks/labs/lsql/core.py
@@ -140,7 +140,7 @@ class StatementExecutionExt:
     megabytes or gigabytes of data serialized in Apache Arrow format, and low result fetching latency, should use
     the stateful Databricks SQL Connector for Python."""
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         ws: WorkspaceClient,
         disposition: Disposition | None = None,

--- a/src/databricks/labs/lsql/deployment.py
+++ b/src/databricks/labs/lsql/deployment.py
@@ -24,25 +24,25 @@ class SchemaDeployer:
         self._inventory_catalog = inventory_catalog
 
     def deploy_schema(self) -> None:
-        schema_name = f"{self._inventory_catalog}.{self._inventory_schema}"
-        logger.info(f"Ensuring {schema_name} database exists")
-        self._sql_backend.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
+        schema_full_name = f"{self._inventory_catalog}.{self._inventory_schema}"
+        logger.info(f"Ensuring {schema_full_name} database exists")
+        self._sql_backend.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_full_name}")
 
     def delete_schema(self) -> None:
-        schema_name = f"{self._inventory_catalog}.{self._inventory_schema}"
-        logger.info(f"Deleting {schema_name} database")
-        self._sql_backend.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+        schema_full_name = f"{self._inventory_catalog}.{self._inventory_schema}"
+        logger.info(f"Deleting {schema_full_name} database")
+        self._sql_backend.execute(f"DROP SCHEMA IF EXISTS {schema_full_name} CASCADE")
 
     def deploy_table(self, name: str, klass: Dataclass) -> None:
-        table_name = f"{self._inventory_catalog}.{self._inventory_schema}.{name}"
-        logger.info(f"Ensuring {table_name} table exists")
-        self._sql_backend.create_table(table_name, klass)
+        table_full_name = f"{self._inventory_catalog}.{self._inventory_schema}.{name}"
+        logger.info(f"Ensuring {table_full_name} table exists")
+        self._sql_backend.create_table(table_full_name, klass)
 
     def deploy_view(self, name: str, relative_filename: str) -> None:
         query = self._load(relative_filename)
-        view_name = f"{self._inventory_catalog}.{self._inventory_schema}.{name}"
-        logger.info(f"Ensuring {view_name} view matches {relative_filename} contents")
-        ddl = f"CREATE OR REPLACE VIEW {view_name} AS {query}"
+        view_full_name = f"{self._inventory_catalog}.{self._inventory_schema}.{name}"
+        logger.info(f"Ensuring {view_full_name} view matches {relative_filename} contents")
+        ddl = f"CREATE OR REPLACE VIEW {view_full_name} AS {query}"
         self._sql_backend.execute(ddl)
 
     def _load(self, relative_filename: str) -> str:

--- a/src/databricks/labs/lsql/deployment.py
+++ b/src/databricks/labs/lsql/deployment.py
@@ -12,26 +12,26 @@ logger = logging.getLogger(__name__)
 
 
 class SchemaDeployer:
-    def __init__(self, sql_backend: SqlBackend, inventory_schema: str, mod: Any):
+    def __init__(self, sql_backend: SqlBackend, inventory_schema: str, mod: Any) -> None:
         self._sql_backend = sql_backend
         self._inventory_schema = inventory_schema
         self._module = mod
 
     # InternalError are retried for resilience on sporadic Databricks issues
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
-    def deploy_schema(self):
+    def deploy_schema(self) -> None:
         logger.info(f"Ensuring {self._inventory_schema} database exists")
         self._sql_backend.execute(f"CREATE SCHEMA IF NOT EXISTS hive_metastore.{self._inventory_schema}")
 
-    def delete_schema(self):
+    def delete_schema(self) -> None:
         logger.info(f"deleting {self._inventory_schema} database")
         self._sql_backend.execute(f"DROP SCHEMA IF EXISTS hive_metastore.{self._inventory_schema} CASCADE")
 
-    def deploy_table(self, name: str, klass: Dataclass):
+    def deploy_table(self, name: str, klass: Dataclass) -> None:
         logger.info(f"Ensuring {self._inventory_schema}.{name} table exists")
         self._sql_backend.create_table(f"hive_metastore.{self._inventory_schema}.{name}", klass)
 
-    def deploy_view(self, name: str, relative_filename: str):
+    def deploy_view(self, name: str, relative_filename: str) -> None:
         query = self._load(relative_filename)
         logger.info(f"Ensuring {self._inventory_schema}.{name} view matches {relative_filename} contents")
         ddl = f"CREATE OR REPLACE VIEW hive_metastore.{self._inventory_schema}.{name} AS {query}"

--- a/src/databricks/labs/lsql/deployment.py
+++ b/src/databricks/labs/lsql/deployment.py
@@ -12,12 +12,15 @@ logger = logging.getLogger(__name__)
 
 
 class SchemaDeployer:
+    """Deploy schema, tables, and views for a given inventory schema.
+
+    InternalError are retried on `SqlBackend.execute` for resilience on sporadic Databricks issues.
+    """
     def __init__(self, sql_backend: SqlBackend, inventory_schema: str, mod: Any) -> None:
         self._sql_backend = sql_backend
         self._inventory_schema = inventory_schema
         self._module = mod
 
-    # InternalError are retried for resilience on sporadic Databricks issues
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def deploy_schema(self) -> None:
         logger.info(f"Ensuring {self._inventory_schema} database exists")

--- a/src/databricks/labs/lsql/deployment.py
+++ b/src/databricks/labs/lsql/deployment.py
@@ -16,36 +16,45 @@ class SchemaDeployer:
 
     InternalError are retried on `SqlBackend.execute` for resilience on sporadic Databricks issues.
     """
-    def __init__(self, sql_backend: SqlBackend, inventory_schema: str, mod: Any) -> None:
+
+    def __init__(
+        self,
+        sql_backend: SqlBackend,
+        inventory_schema: str,
+        mod: Any,
+        *,
+        inventory_catalog: str = "hive_metastore",
+    ) -> None:
         self._sql_backend = sql_backend
         self._inventory_schema = inventory_schema
         self._module = mod
+        self._inventory_catalog = inventory_catalog
 
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def deploy_schema(self) -> None:
         logger.info(f"Ensuring {self._inventory_schema} database exists")
-        self._sql_backend.execute(f"CREATE SCHEMA IF NOT EXISTS hive_metastore.{self._inventory_schema}")
+        self._sql_backend.execute(f"CREATE SCHEMA IF NOT EXISTS {self._inventory_catalog}.{self._inventory_schema}")
 
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def delete_schema(self) -> None:
         logger.info(f"deleting {self._inventory_schema} database")
-        self._sql_backend.execute(f"DROP SCHEMA IF EXISTS hive_metastore.{self._inventory_schema} CASCADE")
+        self._sql_backend.execute(f"DROP SCHEMA IF EXISTS {self._inventory_catalog}.{self._inventory_schema} CASCADE")
 
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def deploy_table(self, name: str, klass: Dataclass) -> None:
         logger.info(f"Ensuring {self._inventory_schema}.{name} table exists")
-        self._sql_backend.create_table(f"hive_metastore.{self._inventory_schema}.{name}", klass)
+        self._sql_backend.create_table(f"{self._inventory_catalog}.{self._inventory_schema}.{name}", klass)
 
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def deploy_view(self, name: str, relative_filename: str) -> None:
         query = self._load(relative_filename)
         logger.info(f"Ensuring {self._inventory_schema}.{name} view matches {relative_filename} contents")
-        ddl = f"CREATE OR REPLACE VIEW hive_metastore.{self._inventory_schema}.{name} AS {query}"
+        ddl = f"CREATE OR REPLACE VIEW {self._inventory_catalog}.{self._inventory_schema}.{name} AS {query}"
         self._sql_backend.execute(ddl)
 
     def _load(self, relative_filename: str) -> str:
         data = pkgutil.get_data(self._module.__name__, relative_filename)
         assert data is not None
         sql = data.decode("utf-8")
-        sql = sql.replace("$inventory", f"hive_metastore.{self._inventory_schema}")
+        sql = sql.replace("$inventory", f"{self._inventory_catalog}.{self._inventory_schema}")
         return sql

--- a/src/databricks/labs/lsql/deployment.py
+++ b/src/databricks/labs/lsql/deployment.py
@@ -25,7 +25,6 @@ class SchemaDeployer:
 
     def delete_schema(self):
         logger.info(f"deleting {self._inventory_schema} database")
-
         self._sql_backend.execute(f"DROP SCHEMA IF EXISTS hive_metastore.{self._inventory_schema} CASCADE")
 
     def deploy_table(self, name: str, klass: Dataclass):

--- a/src/databricks/labs/lsql/deployment.py
+++ b/src/databricks/labs/lsql/deployment.py
@@ -13,34 +13,34 @@ class SchemaDeployer:
     def __init__(
         self,
         sql_backend: SqlBackend,
-        inventory_schema: str,
+        schema: str,
         mod: Any,
         *,
-        inventory_catalog: str = "hive_metastore",
+        catalog: str = "hive_metastore",
     ) -> None:
         self._sql_backend = sql_backend
-        self._inventory_schema = inventory_schema
+        self._schema = schema
         self._module = mod
-        self._inventory_catalog = inventory_catalog
+        self._catalog = catalog
 
     def deploy_schema(self) -> None:
-        schema_full_name = f"{self._inventory_catalog}.{self._inventory_schema}"
+        schema_full_name = f"{self._catalog}.{self._schema}"
         logger.info(f"Ensuring {schema_full_name} database exists")
         self._sql_backend.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_full_name}")
 
     def delete_schema(self) -> None:
-        schema_full_name = f"{self._inventory_catalog}.{self._inventory_schema}"
+        schema_full_name = f"{self._catalog}.{self._schema}"
         logger.info(f"Deleting {schema_full_name} database")
         self._sql_backend.execute(f"DROP SCHEMA IF EXISTS {schema_full_name} CASCADE")
 
     def deploy_table(self, name: str, klass: Dataclass) -> None:
-        table_full_name = f"{self._inventory_catalog}.{self._inventory_schema}.{name}"
+        table_full_name = f"{self._catalog}.{self._schema}.{name}"
         logger.info(f"Ensuring {table_full_name} table exists")
         self._sql_backend.create_table(table_full_name, klass)
 
     def deploy_view(self, name: str, relative_filename: str) -> None:
         query = self._load(relative_filename)
-        view_full_name = f"{self._inventory_catalog}.{self._inventory_schema}.{name}"
+        view_full_name = f"{self._catalog}.{self._schema}.{name}"
         logger.info(f"Ensuring {view_full_name} view matches {relative_filename} contents")
         ddl = f"CREATE OR REPLACE VIEW {view_full_name} AS {query}"
         self._sql_backend.execute(ddl)
@@ -49,5 +49,5 @@ class SchemaDeployer:
         data = pkgutil.get_data(self._module.__name__, relative_filename)
         assert data is not None
         sql = data.decode("utf-8")
-        sql = sql.replace("$inventory", f"{self._inventory_catalog}.{self._inventory_schema}")
+        sql = sql.replace("$inventory", f"{self._catalog}.{self._schema}")
         return sql

--- a/src/databricks/labs/lsql/deployment.py
+++ b/src/databricks/labs/lsql/deployment.py
@@ -26,14 +26,17 @@ class SchemaDeployer:
         logger.info(f"Ensuring {self._inventory_schema} database exists")
         self._sql_backend.execute(f"CREATE SCHEMA IF NOT EXISTS hive_metastore.{self._inventory_schema}")
 
+    @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def delete_schema(self) -> None:
         logger.info(f"deleting {self._inventory_schema} database")
         self._sql_backend.execute(f"DROP SCHEMA IF EXISTS hive_metastore.{self._inventory_schema} CASCADE")
 
+    @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def deploy_table(self, name: str, klass: Dataclass) -> None:
         logger.info(f"Ensuring {self._inventory_schema}.{name} table exists")
         self._sql_backend.create_table(f"hive_metastore.{self._inventory_schema}.{name}", klass)
 
+    @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def deploy_view(self, name: str, relative_filename: str) -> None:
         query = self._load(relative_filename)
         logger.info(f"Ensuring {self._inventory_schema}.{name} view matches {relative_filename} contents")

--- a/src/databricks/labs/lsql/deployment.py
+++ b/src/databricks/labs/lsql/deployment.py
@@ -32,24 +32,28 @@ class SchemaDeployer:
 
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def deploy_schema(self) -> None:
-        logger.info(f"Ensuring {self._inventory_schema} database exists")
-        self._sql_backend.execute(f"CREATE SCHEMA IF NOT EXISTS {self._inventory_catalog}.{self._inventory_schema}")
+        schema_name = f"{self._inventory_catalog}.{self._inventory_schema}"
+        logger.info(f"Ensuring {schema_name} database exists")
+        self._sql_backend.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
 
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def delete_schema(self) -> None:
-        logger.info(f"deleting {self._inventory_schema} database")
-        self._sql_backend.execute(f"DROP SCHEMA IF EXISTS {self._inventory_catalog}.{self._inventory_schema} CASCADE")
+        schema_name = f"{self._inventory_catalog}.{self._inventory_schema}"
+        logger.info(f"Deleting {schema_name} database")
+        self._sql_backend.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
 
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def deploy_table(self, name: str, klass: Dataclass) -> None:
-        logger.info(f"Ensuring {self._inventory_schema}.{name} table exists")
-        self._sql_backend.create_table(f"{self._inventory_catalog}.{self._inventory_schema}.{name}", klass)
+        table_name = f"{self._inventory_catalog}.{self._inventory_schema}.{name}"
+        logger.info(f"Ensuring {table_name} table exists")
+        self._sql_backend.create_table(table_name, klass)
 
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def deploy_view(self, name: str, relative_filename: str) -> None:
         query = self._load(relative_filename)
-        logger.info(f"Ensuring {self._inventory_schema}.{name} view matches {relative_filename} contents")
-        ddl = f"CREATE OR REPLACE VIEW {self._inventory_catalog}.{self._inventory_schema}.{name} AS {query}"
+        view_name = f"{self._inventory_catalog}.{self._inventory_schema}.{name}"
+        logger.info(f"Ensuring {view_name} view matches {relative_filename} contents")
+        ddl = f"CREATE OR REPLACE VIEW {view_name} AS {query}"
         self._sql_backend.execute(ddl)
 
     def _load(self, relative_filename: str) -> str:

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -8,7 +8,7 @@ from . import views
 
 
 @pytest.mark.xfail
-def test_deploys_database(ws, env_or_skip, make_random):
+def test_deploys_database(ws, env_or_skip, make_random) -> None:
     # TODO: create per-project/per-scope catalog
     schema = "default"
     sql_backend = StatementExecutionBackend(ws, env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"))
@@ -24,8 +24,7 @@ def test_deploys_database(ws, env_or_skip, make_random):
     assert rows == [Row(name="abc", id=1)]
 
 
-def test_overwrite(ws, env_or_skip, make_random):
-    schema = "default"
+def test_overwrite(ws, env_or_skip, make_random) -> None:
     sql_backend = StatementExecutionBackend(ws, env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"))
     catalog = env_or_skip("TEST_CATALOG")
     schema = env_or_skip("TEST_SCHEMA")

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -22,15 +22,3 @@ def test_deploys_database(ws, env_or_skip, make_random) -> None:
     rows = list(sql_backend.fetch(f"SELECT * FROM {schema}.some"))
 
     assert rows == [Row(name="abc", id=1)]
-
-
-def test_overwrite(ws, env_or_skip, make_random) -> None:
-    sql_backend = StatementExecutionBackend(ws, env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"))
-    catalog = env_or_skip("TEST_CATALOG")
-    schema = env_or_skip("TEST_SCHEMA")
-
-    sql_backend.save_table(f"{catalog}.{schema}.foo", [views.Foo("abc", True)], views.Foo, "append")
-    sql_backend.save_table(f"{catalog}.{schema}.foo", [views.Foo("xyz", True)], views.Foo, "overwrite")
-    rows = list(sql_backend.fetch(f"SELECT * FROM {catalog}.{schema}.foo"))
-
-    assert rows == [Row(first="xyz", second=True)]

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -1,24 +1,22 @@
-import pytest
 
 from databricks.labs.lsql import Row
-from databricks.labs.lsql.backends import StatementExecutionBackend
 from databricks.labs.lsql.deployment import SchemaDeployer
 
 from . import views
 
 
-@pytest.mark.xfail
-def test_deploys_database(ws, env_or_skip, make_random) -> None:
-    # TODO: create per-project/per-scope catalog
-    schema = "default"
-    sql_backend = StatementExecutionBackend(ws, env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"))
+def test_deploys_schema(ws, sql_backend, make_random, make_catalog) -> None:
+    """Test deploying a full, minimal inventory schema with a single schema, table and view."""
+    catalog = make_catalog(name=f"lsql_test_{make_random()}")
+    schema_name = "lsql_test"
+    table_full_name = f"{catalog.name}.{schema_name}.foo"
 
-    deployer = SchemaDeployer(sql_backend, schema, views)
+    deployer = SchemaDeployer(sql_backend, schema_name, views, inventory_catalog=catalog.name)
     deployer.deploy_schema()
     deployer.deploy_table("foo", views.Foo)
     deployer.deploy_view("some", "some.sql")
 
-    sql_backend.save_table(f"{schema}.foo", [views.Foo("abc", True)], views.Foo)
-    rows = list(sql_backend.fetch(f"SELECT * FROM {schema}.some"))
+    sql_backend.save_table(table_full_name, [views.Foo("abc", True)], views.Foo)
 
-    assert rows == [Row(name="abc", id=1)]
+    rows = list(sql_backend.fetch(f"SELECT * FROM {table_full_name}"))
+    assert rows == [Row(first="abc", second=1)]

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -1,4 +1,3 @@
-
 from databricks.labs.lsql import Row
 from databricks.labs.lsql.deployment import SchemaDeployer
 

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -1,9 +1,12 @@
+import pytest
+
 from databricks.labs.lsql import Row
 from databricks.labs.lsql.deployment import SchemaDeployer
 
 from . import views
 
 
+@pytest.mark.xfail(reason="Identity used in CI misses privileges to create UC resources")
 def test_deploys_schema(ws, sql_backend, make_random, make_catalog) -> None:
     """Test deploying a full, minimal inventory schema with a single schema, table and view."""
     catalog = make_catalog(name=f"lsql_test_{make_random()}")

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -10,7 +10,7 @@ def test_deploys_schema(ws, sql_backend, make_random, make_catalog) -> None:
     schema_name = "lsql_test"
     table_full_name = f"{catalog.name}.{schema_name}.foo"
 
-    deployer = SchemaDeployer(sql_backend, schema_name, views, inventory_catalog=catalog.name)
+    deployer = SchemaDeployer(sql_backend, schema_name, views, catalog=catalog.name)
     deployer.deploy_schema()
     deployer.deploy_table("foo", views.Foo)
     deployer.deploy_view("some", "some.sql")

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -43,26 +43,6 @@ def test_deletes_schema(caplog, inventory_catalog: str) -> None:
     assert f"Deleting {inventory_catalog}.inventory database" in caplog.messages
 
 
-@pytest.mark.parametrize("inventory_catalog", ["hive_metastore", "inventory"])
-def test_deploys_view(caplog, inventory_catalog: str) -> None:
-    mock_backend = MockBackend()
-    deployment = SchemaDeployer(
-        sql_backend=mock_backend,
-        inventory_schema="inventory",
-        mod=views,
-        inventory_catalog=inventory_catalog,
-    )
-
-    with caplog.at_level(logging.INFO, logger="databricks.labs.lsql.deployment"):
-        deployment.deploy_view("some", "some.sql")
-
-    assert mock_backend.queries == [
-        f"CREATE OR REPLACE VIEW {inventory_catalog}.inventory.some AS SELECT\n  id,\n  name\n"
-        f"FROM {inventory_catalog}.inventory.something"
-    ]
-    assert f"Ensuring {inventory_catalog}.inventory.some view matches some.sql contents" in caplog.messages
-
-
 @dataclass
 class Foo:
     first: str
@@ -86,3 +66,23 @@ def test_deploys_dataclass(caplog, inventory_catalog: str) -> None:
         f"CREATE TABLE IF NOT EXISTS {inventory_catalog}.inventory.foo (first STRING NOT NULL, second BOOLEAN NOT NULL) USING DELTA",
     ]
     assert f"Ensuring {inventory_catalog}.inventory.foo table exists" in caplog.messages
+
+
+@pytest.mark.parametrize("inventory_catalog", ["hive_metastore", "inventory"])
+def test_deploys_view(caplog, inventory_catalog: str) -> None:
+    mock_backend = MockBackend()
+    deployment = SchemaDeployer(
+        sql_backend=mock_backend,
+        inventory_schema="inventory",
+        mod=views,
+        inventory_catalog=inventory_catalog,
+    )
+
+    with caplog.at_level(logging.INFO, logger="databricks.labs.lsql.deployment"):
+        deployment.deploy_view("some", "some.sql")
+
+    assert mock_backend.queries == [
+        f"CREATE OR REPLACE VIEW {inventory_catalog}.inventory.some AS SELECT\n  id,\n  name\n"
+        f"FROM {inventory_catalog}.inventory.something"
+    ]
+    assert f"Ensuring {inventory_catalog}.inventory.some view matches some.sql contents" in caplog.messages

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -14,9 +14,9 @@ def test_deploys_schema(caplog, inventory_catalog: str) -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
         sql_backend=mock_backend,
-        inventory_schema="inventory",
+        schema="inventory",
         mod=views,
-        inventory_catalog=inventory_catalog,
+        catalog=inventory_catalog,
     )
 
     with caplog.at_level(logging.INFO, logger="databricks.labs.lsql.deployment"):
@@ -31,9 +31,9 @@ def test_deletes_schema(caplog, inventory_catalog: str) -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
         sql_backend=mock_backend,
-        inventory_schema="inventory",
+        schema="inventory",
         mod=views,
-        inventory_catalog=inventory_catalog,
+        catalog=inventory_catalog,
     )
 
     with caplog.at_level(logging.INFO, logger="databricks.labs.lsql.deployment"):
@@ -54,9 +54,9 @@ def test_deploys_dataclass(caplog, inventory_catalog: str) -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
         sql_backend=mock_backend,
-        inventory_schema="inventory",
+        schema="inventory",
         mod=views,
-        inventory_catalog=inventory_catalog,
+        catalog=inventory_catalog,
     )
 
     with caplog.at_level(logging.INFO, logger="databricks.labs.lsql.deployment"):
@@ -73,9 +73,9 @@ def test_deploys_view(caplog, inventory_catalog: str) -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
         sql_backend=mock_backend,
-        inventory_schema="inventory",
+        schema="inventory",
         mod=views,
-        inventory_catalog=inventory_catalog,
+        catalog=inventory_catalog,
     )
 
     with caplog.at_level(logging.INFO, logger="databricks.labs.lsql.deployment"):

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -6,6 +6,21 @@ from databricks.labs.lsql.deployment import SchemaDeployer
 from . import views
 
 
+def test_deploys_schema() -> None:
+    mock_backend = MockBackend()
+    deployment = SchemaDeployer(
+        sql_backend=mock_backend,
+        inventory_schema="inventory",
+        mod=views,
+    )
+
+    deployment.deploy_schema()
+
+    assert mock_backend.queries == [
+        "CREATE SCHEMA IF NOT EXISTS hive_metastore.inventory"
+    ]
+
+
 def test_deploys_view() -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
@@ -43,3 +58,4 @@ def test_deploys_dataclass() -> None:
         "CREATE TABLE IF NOT EXISTS hive_metastore.inventory.foo (first STRING NOT NULL, second BOOLEAN NOT NULL) USING DELTA",
         "DROP SCHEMA IF EXISTS hive_metastore.inventory CASCADE",
     ]
+

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -6,7 +6,7 @@ from databricks.labs.lsql.deployment import SchemaDeployer
 from . import views
 
 
-def test_deploys_view():
+def test_deploys_view() -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
         sql_backend=mock_backend,
@@ -27,7 +27,7 @@ class Foo:
     second: bool
 
 
-def test_deploys_dataclass():
+def test_deploys_dataclass() -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
         sql_backend=mock_backend,

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -16,9 +16,7 @@ def test_deploys_schema() -> None:
 
     deployment.deploy_schema()
 
-    assert mock_backend.queries == [
-        "CREATE SCHEMA IF NOT EXISTS hive_metastore.inventory"
-    ]
+    assert mock_backend.queries == ["CREATE SCHEMA IF NOT EXISTS hive_metastore.inventory"]
 
 
 def test_deletes_schema() -> None:
@@ -31,9 +29,7 @@ def test_deletes_schema() -> None:
 
     deployment.delete_schema()
 
-    assert mock_backend.queries == [
-        "DROP SCHEMA IF EXISTS hive_metastore.inventory CASCADE"
-    ]
+    assert mock_backend.queries == ["DROP SCHEMA IF EXISTS hive_metastore.inventory CASCADE"]
 
 
 def test_deploys_view() -> None:
@@ -73,4 +69,3 @@ def test_deploys_dataclass() -> None:
         "CREATE TABLE IF NOT EXISTS hive_metastore.inventory.foo (first STRING NOT NULL, second BOOLEAN NOT NULL) USING DELTA",
         "DROP SCHEMA IF EXISTS hive_metastore.inventory CASCADE",
     ]
-

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -1,49 +1,58 @@
 from dataclasses import dataclass
 
+import pytest
+
 from databricks.labs.lsql.backends import MockBackend
 from databricks.labs.lsql.deployment import SchemaDeployer
 
 from . import views
 
 
-def test_deploys_schema() -> None:
+@pytest.mark.parametrize("inventory_catalog", ["hive_metastore", "inventory"])
+def test_deploys_schema(inventory_catalog: str) -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
         sql_backend=mock_backend,
         inventory_schema="inventory",
         mod=views,
+        inventory_catalog=inventory_catalog,
     )
 
     deployment.deploy_schema()
 
-    assert mock_backend.queries == ["CREATE SCHEMA IF NOT EXISTS hive_metastore.inventory"]
+    assert mock_backend.queries == [f"CREATE SCHEMA IF NOT EXISTS {inventory_catalog}.inventory"]
 
 
-def test_deletes_schema() -> None:
+@pytest.mark.parametrize("inventory_catalog", ["hive_metastore", "inventory"])
+def test_deletes_schema(inventory_catalog: str) -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
         sql_backend=mock_backend,
         inventory_schema="inventory",
         mod=views,
+        inventory_catalog=inventory_catalog,
     )
 
     deployment.delete_schema()
 
-    assert mock_backend.queries == ["DROP SCHEMA IF EXISTS hive_metastore.inventory CASCADE"]
+    assert mock_backend.queries == [f"DROP SCHEMA IF EXISTS {inventory_catalog}.inventory CASCADE"]
 
 
-def test_deploys_view() -> None:
+@pytest.mark.parametrize("inventory_catalog", ["hive_metastore", "inventory"])
+def test_deploys_view(inventory_catalog: str) -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
         sql_backend=mock_backend,
         inventory_schema="inventory",
         mod=views,
+        inventory_catalog=inventory_catalog,
     )
 
     deployment.deploy_view("some", "some.sql")
 
     assert mock_backend.queries == [
-        "CREATE OR REPLACE VIEW hive_metastore.inventory.some AS SELECT\n  id,\n  name\nFROM hive_metastore.inventory.something"
+        f"CREATE OR REPLACE VIEW {inventory_catalog}.inventory.some AS SELECT\n  id,\n  name\n"
+        f"FROM {inventory_catalog}.inventory.something"
     ]
 
 
@@ -53,19 +62,21 @@ class Foo:
     second: bool
 
 
-def test_deploys_dataclass() -> None:
+@pytest.mark.parametrize("inventory_catalog", ["hive_metastore", "inventory"])
+def test_deploys_dataclass(inventory_catalog: str) -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(
         sql_backend=mock_backend,
         inventory_schema="inventory",
         mod=views,
+        inventory_catalog=inventory_catalog,
     )
     deployment.deploy_schema()
     deployment.deploy_table("foo", Foo)
     deployment.delete_schema()
 
     assert mock_backend.queries == [
-        "CREATE SCHEMA IF NOT EXISTS hive_metastore.inventory",
-        "CREATE TABLE IF NOT EXISTS hive_metastore.inventory.foo (first STRING NOT NULL, second BOOLEAN NOT NULL) USING DELTA",
-        "DROP SCHEMA IF EXISTS hive_metastore.inventory CASCADE",
+        f"CREATE SCHEMA IF NOT EXISTS {inventory_catalog}.inventory",
+        f"CREATE TABLE IF NOT EXISTS {inventory_catalog}.inventory.foo (first STRING NOT NULL, second BOOLEAN NOT NULL) USING DELTA",
+        f"DROP SCHEMA IF EXISTS {inventory_catalog}.inventory CASCADE",
     ]

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -21,6 +21,21 @@ def test_deploys_schema() -> None:
     ]
 
 
+def test_deletes_schema() -> None:
+    mock_backend = MockBackend()
+    deployment = SchemaDeployer(
+        sql_backend=mock_backend,
+        inventory_schema="inventory",
+        mod=views,
+    )
+
+    deployment.delete_schema()
+
+    assert mock_backend.queries == [
+        "DROP SCHEMA IF EXISTS hive_metastore.inventory CASCADE"
+    ]
+
+
 def test_deploys_view() -> None:
     mock_backend = MockBackend()
     deployment = SchemaDeployer(


### PR DESCRIPTION
Set catalog on `SchemaDeployer` to overwrite the default `hive_metastore`

### Linked issues

Resolves #294
Needs #280 (tech debt to tackle later)
Progresses #278
Requires #287 for the CI to pass