### PR TITLE
Minor improvements for `.save_table(mode="overwrite")`

### DIFF
--- a/src/databricks/labs/lsql/backends.py
+++ b/src/databricks/labs/lsql/backends.py
@@ -135,7 +135,13 @@ class ExecutionBackend(SqlBackend):
     def fetch(self, sql: str, *, catalog: str | None = None, schema: str | None = None) -> Iterator[Any]:
         raise NotImplementedError
 
-    def save_table(self, full_name: str, rows: Sequence[DataclassInstance], klass: Dataclass, mode="append"):
+    def save_table(
+        self,
+        full_name: str,
+        rows: Sequence[DataclassInstance],
+        klass: Dataclass,
+        mode: Literal["append", "overwrite"] = "append",
+    ):
         rows = self._filter_none_rows(rows, klass)
         self.create_table(full_name, klass)
         if len(rows) == 0:

--- a/src/databricks/labs/lsql/backends.py
+++ b/src/databricks/labs/lsql/backends.py
@@ -144,7 +144,9 @@ class ExecutionBackend(SqlBackend):
     ):
         rows = self._filter_none_rows(rows, klass)
         self.create_table(full_name, klass)
-        if len(rows) == 0:
+        if not rows:
+            if mode == "overwrite":
+                self.execute(f"TRUNCATE TABLE {full_name}")
             return
         fields = dataclasses.fields(klass)
         field_names = [f.name for f in fields]
@@ -284,8 +286,7 @@ class _SparkBackend(SqlBackend):
         mode: Literal["append", "overwrite"] = "append",
     ) -> None:
         rows = self._filter_none_rows(rows, klass)
-
-        if len(rows) == 0:
+        if not rows and mode == "append":
             self.create_table(full_name, klass)
             return
         # pyspark deals well with lists of dataclass instances, as long as schema is provided

--- a/tests/integration/test_backends.py
+++ b/tests/integration/test_backends.py
@@ -162,6 +162,10 @@ def test_statement_execution_backend_overwrites_table(ws, env_or_skip, make_rand
     rows = list(sql_backend.fetch(f"SELECT * FROM {catalog}.{schema}.foo"))
     assert rows == [Row(first="xyz", second=True)]
 
+    sql_backend.save_table(f"{catalog}.{schema}.foo", [], views.Foo, "overwrite")
+
+    rows = list(sql_backend.fetch(f"SELECT * FROM {catalog}.{schema}.foo"))
+    assert rows == []
 
 def test_runtime_backend_use_statements(ws):
     product_info = ProductInfo.for_testing(SqlBackend)

--- a/tests/integration/test_backends.py
+++ b/tests/integration/test_backends.py
@@ -167,6 +167,7 @@ def test_statement_execution_backend_overwrites_table(ws, env_or_skip, make_rand
     rows = list(sql_backend.fetch(f"SELECT * FROM {catalog}.{schema}.foo"))
     assert rows == []
 
+
 def test_runtime_backend_use_statements(ws):
     product_info = ProductInfo.for_testing(SqlBackend)
     installation = Installation.assume_user_home(ws, product_info.product_name())

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -170,7 +170,7 @@ def test_statement_execution_backend_save_table_empty_records():
 
     seb.save_table("a.b.c", [], Bar)
 
-    ws.statement_execution.execute_statement.assert_called_with(
+    ws.statement_execution.execute_statement.assert_called_once_with(
         warehouse_id="abc",
         statement="CREATE TABLE IF NOT EXISTS a.b.c "
         "(first STRING NOT NULL, second BOOLEAN NOT NULL, third FLOAT NOT NULL) USING DELTA",
@@ -308,7 +308,7 @@ def test_runtime_backend_save_table():
 
         runtime_backend.save_table("a.b.c", [Foo("aaa", True), Foo("bbb", False)], Foo)
 
-        spark.createDataFrame.assert_called_with(
+        spark.createDataFrame.assert_called_once_with(
             [Foo(first="aaa", second=True), Foo(first="bbb", second=False)],
             "first STRING NOT NULL, second BOOLEAN NOT NULL",
         )

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import sys
 from dataclasses import dataclass
+from typing import Literal
 from unittest import mock
 from unittest.mock import MagicMock, call, create_autospec
 
@@ -173,7 +174,7 @@ def test_statement_execution_backend_save_table_empty_records():
     )
 
 
-def test_statement_execution_backend_save_table_overwrite_empty_records():
+def test_statement_execution_backend_save_table_overwrite_empty_records() -> None:
     ws = create_autospec(WorkspaceClient)
 
     ws.statement_execution.execute_statement.return_value = StatementResponse(
@@ -248,7 +249,7 @@ def test_statement_execution_backend_save_table_two_records():
     )
 
 
-def test_statement_execution_backend_save_table_append_in_batches_of_two():
+def test_statement_execution_backend_save_table_append_in_batches_of_two() -> None:
     ws = create_autospec(WorkspaceClient)
 
     ws.statement_execution.execute_statement.return_value = StatementResponse(
@@ -295,7 +296,7 @@ def test_statement_execution_backend_save_table_append_in_batches_of_two():
     )
 
 
-def test_statement_execution_backend_save_table_overwrite_in_batches_of_two():
+def test_statement_execution_backend_save_table_overwrite_in_batches_of_two() -> None:
     ws = create_autospec(WorkspaceClient)
 
     ws.statement_execution.execute_statement.return_value = StatementResponse(
@@ -374,7 +375,7 @@ def test_runtime_backend_fetch():
 
 
 @pytest.mark.parametrize("mode", ["append", "overwrite"])
-def test_runtime_backend_save_table(mode):
+def test_runtime_backend_save_table(mode: Literal["append", "overwrite"]) -> None:
     with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
         pyspark_sql_session = MagicMock()
         sys.modules["pyspark.sql.session"] = pyspark_sql_session
@@ -391,7 +392,7 @@ def test_runtime_backend_save_table(mode):
         spark.createDataFrame().write.saveAsTable.assert_called_once_with("a.b.c", mode=mode)
 
 
-def test_runtime_backend_save_table_append_empty_records():
+def test_runtime_backend_save_table_append_empty_records() -> None:
     with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
         pyspark_sql_session = MagicMock()
         sys.modules["pyspark.sql.session"] = pyspark_sql_session
@@ -408,7 +409,7 @@ def test_runtime_backend_save_table_append_empty_records():
         )
 
 
-def test_runtime_backend_save_table_overwrite_empty_records():
+def test_runtime_backend_save_table_overwrite_empty_records() -> None:
     with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
         pyspark_sql_session = MagicMock()
         sys.modules["pyspark.sql.session"] = pyspark_sql_session
@@ -534,7 +535,7 @@ def test_mock_backend_save_table_overwrite() -> None:
     ]
 
 
-def test_mock_backend_save_table_no_rows():
+def test_mock_backend_save_table_no_rows() -> None:
     mock_backend = MockBackend()
 
     mock_backend.save_table("a.b.c", [Foo("aaa", True), Foo("bbb", False)], Foo)
@@ -546,7 +547,7 @@ def test_mock_backend_save_table_no_rows():
     ]
 
 
-def test_mock_backend_save_table_overwrite_no_rows():
+def test_mock_backend_save_table_overwrite_no_rows() -> None:
     mock_backend = MockBackend()
 
     mock_backend.save_table("a.b.c", [Foo("aaa", True), Foo("bbb", False)], Foo)

--- a/tests/unit/test_command_execution_backend.py
+++ b/tests/unit/test_command_execution_backend.py
@@ -158,7 +158,7 @@ def test_command_context_backend_save_table_empty_records():
     )
 
 
-def test_command_context_backend_save_table_overwrite_empty_records():
+def test_command_context_backend_save_table_overwrite_empty_records() -> None:
     ws = create_autospec(WorkspaceClient)
     ws.command_execution.create.return_value = Wait[ContextStatusResponse](
         waiter=lambda callback, timeout: ContextStatusResponse(id="abc")
@@ -225,7 +225,7 @@ def test_command_context_backend_save_table_two_records():
     )
 
 
-def test_command_context_backend_save_table_append_in_batches_of_two():
+def test_command_context_backend_save_table_append_in_batches_of_two() -> None:
     ws = create_autospec(WorkspaceClient)
     ws.command_execution.create.return_value = Wait[ContextStatusResponse](
         waiter=lambda callback, timeout: ContextStatusResponse(id="abc")
@@ -264,7 +264,7 @@ def test_command_context_backend_save_table_append_in_batches_of_two():
     )
 
 
-def test_command_context_backend_save_table_overwrite_in_batches_of_two():
+def test_command_context_backend_save_table_overwrite_in_batches_of_two() -> None:
     ws = create_autospec(WorkspaceClient)
     ws.command_execution.create.return_value = Wait[ContextStatusResponse](
         waiter=lambda callback, timeout: ContextStatusResponse(id="abc")

--- a/tests/unit/test_command_execution_backend.py
+++ b/tests/unit/test_command_execution_backend.py
@@ -155,7 +155,7 @@ def test_command_context_backend_save_table_empty_records():
 
     ceb.save_table("a.b.c", [], Bar)
 
-    ws.command_execution.execute.assert_called_with(
+    ws.command_execution.execute.assert_called_once_with(
         cluster_id="abc",
         language=Language.SQL,
         context_id="abc",

--- a/tests/unit/test_command_execution_backend.py
+++ b/tests/unit/test_command_execution_backend.py
@@ -128,13 +128,7 @@ def test_command_context_backend_save_table_overwrite_empty_table():
                 cluster_id="abc",
                 language=Language.SQL,
                 context_id="abc",
-                command="TRUNCATE TABLE a.b.c",
-            ),
-            mock.call(
-                cluster_id="abc",
-                language=Language.SQL,
-                context_id="abc",
-                command="INSERT INTO a.b.c (first, second) VALUES ('1', NULL)",
+                command="INSERT OVERWRITE a.b.c (first, second) VALUES ('1', NULL)",
             ),
         ]
     )
@@ -197,7 +191,7 @@ def test_command_context_backend_save_table_two_records():
     )
 
 
-def test_command_context_backend_save_table_in_batches_of_two(mocker):
+def test_command_context_backend_save_table_append_in_batches_of_two():
     ws = create_autospec(WorkspaceClient)
     ws.command_execution.create.return_value = Wait[ContextStatusResponse](
         waiter=lambda callback, timeout: ContextStatusResponse(id="abc")
@@ -210,7 +204,7 @@ def test_command_context_backend_save_table_in_batches_of_two(mocker):
 
     ceb = CommandExecutionBackend(ws, "abc", max_records_per_batch=2)
 
-    ceb.save_table("a.b.c", [Foo("aaa", True), Foo("bbb", False), Foo("ccc", True)], Foo)
+    ceb.save_table("a.b.c", [Foo("aaa", True), Foo("bbb", False), Foo("ccc", True)], Foo, mode="append")
 
     ws.command_execution.execute.assert_has_calls(
         [
@@ -225,6 +219,45 @@ def test_command_context_backend_save_table_in_batches_of_two(mocker):
                 language=Language.SQL,
                 context_id="abc",
                 command="INSERT INTO a.b.c (first, second) VALUES ('aaa', TRUE), ('bbb', FALSE)",
+            ),
+            mock.call(
+                cluster_id="abc",
+                language=Language.SQL,
+                context_id="abc",
+                command="INSERT INTO a.b.c (first, second) VALUES ('ccc', TRUE)",
+            ),
+        ]
+    )
+
+
+def test_command_context_backend_save_table_overwrite_in_batches_of_two():
+    ws = create_autospec(WorkspaceClient)
+    ws.command_execution.create.return_value = Wait[ContextStatusResponse](
+        waiter=lambda callback, timeout: ContextStatusResponse(id="abc")
+    )
+    ws.command_execution.execute.return_value = Wait[CommandStatusResponse](
+        waiter=lambda callback, timeout: CommandStatusResponse(
+            results=Results(data="success"), status=CommandStatus.FINISHED
+        )
+    )
+
+    ceb = CommandExecutionBackend(ws, "abc", max_records_per_batch=2)
+
+    ceb.save_table("a.b.c", [Foo("aaa", True), Foo("bbb", False), Foo("ccc", True)], Foo, mode="overwrite")
+
+    ws.command_execution.execute.assert_has_calls(
+        [
+            mock.call(
+                cluster_id="abc",
+                language=Language.SQL,
+                context_id="abc",
+                command="CREATE TABLE IF NOT EXISTS a.b.c (first STRING NOT NULL, second BOOLEAN NOT NULL) USING DELTA",
+            ),
+            mock.call(
+                cluster_id="abc",
+                language=Language.SQL,
+                context_id="abc",
+                command="INSERT OVERWRITE a.b.c (first, second) VALUES ('aaa', TRUE), ('bbb', FALSE)",
             ),
             mock.call(
                 cluster_id="abc",


### PR DESCRIPTION
This PR includes some updates for `.save_table()` in overwrite mode:

 - If no rows are supplied, instead of a no-op the table is truncated. The mock backend already assumed this but diverged from the concrete implementations which treated this as a no-op (as when appending). Unit tests now cover this situation for all backends, and the existing integration test for the SQL-statement backend has been updated to cover this.
 - The SQL-based backends have a slight optimisation: instead of first truncating before inserting the truncate is now performed as part of the insert for the first batch.
 - Type hints on the abstract method now match the concrete implementations.