### PR TITLE
Add support for cellFormat in TableV1ColumnEncoding

### DIFF
--- a/src/databricks/labs/lsql/lakeview/model.py
+++ b/src/databricks/labs/lsql/lakeview/model.py
@@ -1554,6 +1554,7 @@ class TableV1ColumnEncoding:
     preserve_whitespace: bool | None = None
     use_monospace_font: bool | None = None
     visible: bool | None = None
+    cellFormat: dict | None = None
 
     def as_dict(self) -> Json:
         body: Json = {}
@@ -1611,6 +1612,8 @@ class TableV1ColumnEncoding:
             body["useMonospaceFont"] = self.use_monospace_font
         if self.visible is not None:
             body["visible"] = self.visible
+        if self.cellFormat:
+            body["cellFormat"] = self.cellFormat
         return body
 
     @classmethod
@@ -1643,6 +1646,7 @@ class TableV1ColumnEncoding:
             type=_enum(d, "type", ColumnType),
             use_monospace_font=d.get("useMonospaceFont", None),
             visible=d.get("visible", None),
+            cellFormat=d.get("cellFormat", None),
         )
 
 


### PR DESCRIPTION
Add support for cellFormat in TableV1ColumnEncoding.

Although the models.py file is autogenerated, this PR tries to manually add support for cellFormat in TableV1ColumnEncoding. It can be considered a temporary solution until a new model.py file is generated.

cellFormat is required by some dashboard implementations for conditional formatting.
Ref: https://github.com/databrickslabs/remorph/pull/768

Can we proceed with it?
