### PR TITLE
Handle changes from Databricks Python SDK 0.37.0

### DIFF
--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -1133,9 +1133,9 @@ class Dashboards:
             warehouse_id=warehouse_id,
         )
         if dashboard_id is not None:
-            sdk_dashboard = self._ws.lakeview.update(dashboard_id, dashboard=dashboard_to_create)
+            sdk_dashboard = self._ws.lakeview.update(dashboard_id, dashboard=dashboard_to_create.as_dict())  # type: ignore
         else:
-            sdk_dashboard = self._ws.lakeview.create(dashboard=dashboard_to_create)
+            sdk_dashboard = self._ws.lakeview.create(dashboard=dashboard_to_create.as_dict())  # type: ignore
         if publish:
             assert sdk_dashboard.dashboard_id is not None
             self._ws.lakeview.publish(sdk_dashboard.dashboard_id, warehouse_id=warehouse_id)

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -1125,20 +1125,17 @@ class Dashboards:
         """
         dashboard_metadata.validate()
         serialized_dashboard = json.dumps(dashboard_metadata.as_lakeview().as_dict())
+        dashboard_to_create = SDKDashboard(
+            dashboard_id=dashboard_id,
+            display_name=dashboard_metadata.display_name,
+            parent_path=parent_path,
+            serialized_dashboard=serialized_dashboard,
+            warehouse_id=warehouse_id,
+        )
         if dashboard_id is not None:
-            sdk_dashboard = self._ws.lakeview.update(
-                dashboard_id,
-                display_name=dashboard_metadata.display_name,
-                serialized_dashboard=serialized_dashboard,
-                warehouse_id=warehouse_id,
-            )
+            sdk_dashboard = self._ws.lakeview.update(dashboard_id, dashboard=dashboard_to_create)
         else:
-            sdk_dashboard = self._ws.lakeview.create(
-                dashboard_metadata.display_name,
-                parent_path=parent_path,
-                serialized_dashboard=serialized_dashboard,
-                warehouse_id=warehouse_id,
-            )
+            sdk_dashboard = self._ws.lakeview.create(dashboard=dashboard_to_create)
         if publish:
             assert sdk_dashboard.dashboard_id is not None
             self._ws.lakeview.publish(sdk_dashboard.dashboard_id, warehouse_id=warehouse_id)

--- a/tests/integration/test_dashboards.py
+++ b/tests/integration/test_dashboards.py
@@ -58,7 +58,7 @@ def make_dashboard(ws, make_random):
             display_name = f"created_by_lsql_{make_random()}"
         else:
             display_name = f"{display_name} ({make_random()})"
-        dashboard = ws.lakeview.create(dashboard=SDKDashboard(display_name=display_name))
+        dashboard = ws.lakeview.create(dashboard=SDKDashboard(display_name=display_name).as_dict())
         if is_in_debug():
             dashboard_url = f"{ws.config.host}/sql/dashboardsv3/{dashboard.dashboard_id}"
             webbrowser.open(dashboard_url)
@@ -117,7 +117,7 @@ def test_dashboards_creates_exported_dashboard_definition(ws, make_dashboard) ->
     dashboard_content = (Path(__file__).parent / "dashboards" / "dashboard.lvdash.json").read_text()
 
     dashboard_to_create = dataclasses.replace(sdk_dashboard, serialized_dashboard=dashboard_content)
-    ws.lakeview.update(sdk_dashboard.dashboard_id, dashboard=dashboard_to_create)
+    ws.lakeview.update(sdk_dashboard.dashboard_id, dashboard=dashboard_to_create.as_dict())
     lakeview_dashboard = Dashboard.from_dict(json.loads(dashboard_content))
     new_dashboard = dashboards.get_dashboard(sdk_dashboard.path)
 

--- a/tests/integration/test_dashboards.py
+++ b/tests/integration/test_dashboards.py
@@ -57,7 +57,7 @@ def make_dashboard(ws, make_random):
             display_name = f"created_by_lsql_{make_random()}"
         else:
             display_name = f"{display_name} ({make_random()})"
-        dashboard = ws.lakeview.create(display_name)
+        dashboard = ws.lakeview.create(dashboard=SDKDashboard(display_name=display_name))
         if is_in_debug():
             dashboard_url = f"{ws.config.host}/sql/dashboardsv3/{dashboard.dashboard_id}"
             webbrowser.open(dashboard_url)

--- a/tests/integration/test_dashboards.py
+++ b/tests/integration/test_dashboards.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime as dt
 import json
 import logging
@@ -110,12 +111,13 @@ def tmp_path(tmp_path, make_random):
     return folder
 
 
-def test_dashboards_creates_exported_dashboard_definition(ws, make_dashboard):
+def test_dashboards_creates_exported_dashboard_definition(ws, make_dashboard) -> None:
     dashboards = Dashboards(ws)
     sdk_dashboard = make_dashboard()
     dashboard_content = (Path(__file__).parent / "dashboards" / "dashboard.lvdash.json").read_text()
 
-    ws.lakeview.update(sdk_dashboard.dashboard_id, serialized_dashboard=dashboard_content)
+    dashboard_to_create = dataclasses.replace(sdk_dashboard, serialized_dashboard=dashboard_content)
+    ws.lakeview.update(sdk_dashboard.dashboard_id, dashboard=dashboard_to_create)
     lakeview_dashboard = Dashboard.from_dict(json.loads(dashboard_content))
     new_dashboard = dashboards.get_dashboard(sdk_dashboard.path)
 

--- a/tests/integration/test_dashboards.py
+++ b/tests/integration/test_dashboards.py
@@ -52,7 +52,7 @@ def factory(name, create, remove):
 def make_dashboard(ws, make_random):
     """Clean the lakeview dashboard"""
 
-    def create(display_name: str = "") -> SDKDashboard:
+    def create(*, display_name: str = "") -> SDKDashboard:
         if len(display_name) == 0:
             display_name = f"created_by_lsql_{make_random()}"
         else:

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1464,24 +1464,33 @@ def test_dashboards_saves_markdown_files_to_folder(tmp_path):
     ws.assert_not_called()
 
 
-def test_dashboards_calls_create_without_dashboard_id():
+def test_dashboards_calls_create_without_dashboard_id() -> None:
+    sdk_dashboard = SDKDashboard(
+        dashboard_id=None,
+        display_name="test",
+        parent_path="/non/existing/path",
+        serialized_dashboard=json.dumps({"pages": [{"displayName": "test", "name": "test"}]}),
+        warehouse_id="warehouse",
+    )
     ws = create_autospec(WorkspaceClient)
     dashboards = Dashboards(ws)
     dashboard_metadata = DashboardMetadata("test")
 
     dashboards.create_dashboard(dashboard_metadata, parent_path="/non/existing/path", warehouse_id="warehouse")
 
-    ws.lakeview.create.assert_called_with(
-        "test",
-        parent_path="/non/existing/path",
-        serialized_dashboard=json.dumps({"pages": [{"displayName": "test", "name": "test"}]}),
-        warehouse_id="warehouse",
-    )
+    ws.lakeview.create.assert_called_with(dashboard=sdk_dashboard.as_dict())
     ws.lakeview.update.assert_not_called()
     ws.lakeview.publish.assert_not_called()
 
 
-def test_dashboards_calls_update_with_dashboard_id():
+def test_dashboards_calls_update_with_dashboard_id() -> None:
+    sdk_dashboard = SDKDashboard(
+        dashboard_id="id",
+        display_name="test",
+        parent_path=None,
+        serialized_dashboard=json.dumps({"pages": [{"displayName": "test", "name": "test"}]}),
+        warehouse_id="warehouse",
+    )
     ws = create_autospec(WorkspaceClient)
     dashboards = Dashboards(ws)
     dashboard_metadata = DashboardMetadata("test")
@@ -1489,12 +1498,7 @@ def test_dashboards_calls_update_with_dashboard_id():
     dashboards.create_dashboard(dashboard_metadata, dashboard_id="id", warehouse_id="warehouse")
 
     ws.lakeview.create.assert_not_called()
-    ws.lakeview.update.assert_called_with(
-        "id",
-        display_name="test",
-        serialized_dashboard=json.dumps({"pages": [{"displayName": "test", "name": "test"}]}),
-        warehouse_id="warehouse",
-    )
+    ws.lakeview.update.assert_called_with("id", dashboard=sdk_dashboard.as_dict())
     ws.lakeview.publish.assert_not_called()
 
 


### PR DESCRIPTION
Handle changes from Databricks Python SDK 0.37.0: LakeviewAPI now works with a Dashboard object

- [ ] ~Requires [change in Python SDK](https://github.com/databricks/databricks-sdk-py/pull/824)~ --> Implemented workaround, see [this issue](https://github.com/databrickslabs/lsql/issues/321) about removing the workaround when the SDK resolved the LakeviewAPI deployment issues