### PR TITLE
Specify the minimum required version of `databricks-sdk` as 0.37.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "databricks-labs-blueprint[yaml]>=0.4.2",
-  "databricks-sdk>=0.29.0",
+  "databricks-sdk~=0.37",
   "sqlglot>=22.3.1"
 ]
 


### PR DESCRIPTION
This PR updates the project specification to require a Databricks SDK version compatible with 0.37.0. This is needed since the changes in #320.

Resolves #330.