### PR TITLE
Validate resource names

### DIFF
--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -266,6 +266,15 @@ class TileMetadata:
         if not self.id:
             self.id = self.path.stem if self.path is not None else ""
 
+    def validate(self) -> None:
+        """Validate the tile metadata.
+
+        Raises:
+            ValueError : If the tile metadata is invalid.
+        """
+        if not self.id:
+            raise ValueError(f"Tile id cannot be empty: {self}")
+
     def merge(self, other: "TileMetadata") -> "TileMetadata":
         """Merge the tile metadata with another tile metadata.
 

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -56,6 +56,17 @@ _MAXIMUM_DASHBOARD_WIDTH = 6
 _SQL_DIALECT = sqlglot.dialects.Databricks
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
+_INVALID_RESOURCE_NAME_MESSAGE = (
+    "Resource names should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_)"
+)
+
+
+def _is_valid_resource_name(name: str) -> bool:
+    """Verify if the resource name is valid.
+
+    What is valid is defined by the Lakeview API, not by lsql.
+    """
+    return name.replace("-", "").replace("_", "").isalnum()
 
 
 class BaseHandler:
@@ -274,6 +285,8 @@ class TileMetadata:
         """
         if not self.id:
             raise ValueError(f"Tile id cannot be empty: {self}")
+        if not _is_valid_resource_name(self.id):
+            raise ValueError(f"{_INVALID_RESOURCE_NAME_MESSAGE}: {self}")
 
     def merge(self, other: "TileMetadata") -> "TileMetadata":
         """Merge the tile metadata with another tile metadata.
@@ -393,6 +406,7 @@ class Tile:
         Raises:
             ValueError : If the tile is invalid.
         """
+        self.metadata.validate()
         if len(self.content) == 0:
             raise ValueError(f"Tile has empty content: {self}")
 

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -275,7 +275,10 @@ class TileMetadata:
 
     def __post_init__(self):
         if not self.id:
-            self.id = self.path.stem if self.path is not None else ""
+            path_stem = "" if self.path is None else self.path.stem
+            if self.is_filter():  # To adhere to :func:_is_valid_resource_name
+                path_stem = path_stem.replace(".filter", "_filter")
+            self.id = path_stem
 
     def validate(self) -> None:
         """Validate the tile metadata.

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -218,7 +218,9 @@ class FilterHandler(BaseHandler):
 
     def split(self) -> tuple[str, str]:
         trimmed_content = self._content.strip()
-        return trimmed_content, ""
+        # Current filter implementation only uses the filter header; the body is not implemented
+        # We return a non-empty body to signal that we know the body is not implemented and not actually empty
+        return trimmed_content, "NOT IMPLEMENTED"
 
 
 @unique
@@ -780,6 +782,7 @@ class FilterTile(Tile):
         Raises:
             ValueError : If the tile is invalid.
         """
+        super().validate()
         if not self.metadata.is_filter():
             raise ValueError(f"Tile is not a filter file: {self}")
         if len(self.metadata.filters) == 0:

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1691,9 +1691,8 @@ type: TABLE
 """.lstrip()
     (tmp_path / "filter_spec.filter.yml").write_text(filter_spec)
     dashboard_metadata = DashboardMetadata.from_path(tmp_path)
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="Filter tile has an invalid widget type: .*"):
         dashboard_metadata.validate()
-    assert "Filter tile has an invalid widget type" in str(e.value)
 
 
 def test_filter_spec_validate_both_column_keys_present(tmp_path):

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import logging
+import re
 import string
 from pathlib import Path
 from unittest.mock import create_autospec
@@ -218,6 +219,18 @@ def test_tile_metadata_validate_raises_value_error_for_empty_id() -> None:
     """The tile metadata id cannot be empty."""
     tile_metadata = TileMetadata()
     with pytest.raises(ValueError, match=f"Tile id cannot be empty: {tile_metadata}"):
+        tile_metadata.validate()
+
+
+def test_tile_metadata_validate_raises_value_error_for_non_alphanumeric_id() -> None:
+    """The tile metadata id cannot be empty."""
+    tile_metadata = TileMetadata(id=")contains#special@characters")
+
+    match = re.escape(
+        "Resource names should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_): "
+        + str(tile_metadata)
+    )
+    with pytest.raises(ValueError, match=match):
         tile_metadata.validate()
 
 

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -19,6 +19,7 @@ from databricks.labs.lsql.dashboards import (
     BaseHandler,
     DashboardMetadata,
     Dashboards,
+    FilterTile,
     MarkdownHandler,
     MarkdownTile,
     QueryHandler,
@@ -524,9 +525,18 @@ def test_tile_metadata_as_dict(tmp_path):
     assert tile_metadata.as_dict() == raw
 
 
-@pytest.mark.parametrize("tile_class", [Tile, QueryTile])
-def test_tile_validate_raises_value_error_when_content_is_empty(tmp_path, tile_class):
-    tile_metadata_path = tmp_path / "test.sql"
+@pytest.mark.parametrize(
+    "tile_class, extension",
+    [
+        (Tile, ".txt"),
+        (MarkdownTile, ".md"),
+        (QueryTile, ".sql"),
+        (FilterTile, ".filter.json"),
+    ],
+)
+def test_tile_validate_raises_value_error_when_content_is_empty(tmp_path, tile_class: Tile, extension: str) -> None:
+    """Tile should have non-empty content"""
+    tile_metadata_path = tmp_path / f"test{extension}"
     tile_metadata_path.touch()
     tile = tile_class(TileMetadata(tile_metadata_path))
 

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -214,6 +214,13 @@ def test_dashboard_metadata_validate_finds_duplicate_widget_id(tmp_path):
     assert "Duplicate id: widget" in str(e.value)
 
 
+def test_tile_metadata_validate_raises_value_error_for_empty_id() -> None:
+    """The tile metadata id cannot be empty."""
+    tile_metadata = TileMetadata()
+    with pytest.raises(ValueError, match=f"Tile id cannot be empty: {tile_metadata}"):
+        tile_metadata.validate()
+
+
 def test_tile_metadata_is_markdown():
     tile_metadata = TileMetadata(Path("test.md"))
     assert tile_metadata.is_markdown()

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -544,12 +544,21 @@ def test_tile_validate_raises_value_error_when_content_is_empty(tmp_path, tile_c
         tile.validate()
 
 
-@pytest.mark.parametrize("tile_class", [Tile, QueryTile])
-def test_tile_validate_raises_value_error_when_name_contains_spaces(tmp_path, tile_class):
+@pytest.mark.parametrize(
+    "tile_class, extension, contents",
+    [
+        (Tile, ".txt", "contents"),
+        (MarkdownTile, ".md", "# Contents"),
+        (QueryTile, ".sql", "SELECT 'contents'"),
+        (FilterTile, ".filter.json", "title: Contents"),
+    ],
+)
+def test_tile_validate_raises_value_error_when_name_contains_spaces(
+    tmp_path, tile_class: Tile, extension: str, contents: str
+) -> None:
     """A tile name cannot contain spaces"""
-    tile_metadata_path = tmp_path / "test with spaces.sql"
-    tile_metadata_path.write_text("SELECT 1")
-    tile = tile_class(TileMetadata(tile_metadata_path))
+    tile_metadata_path = tmp_path / f"test with spaces{extension}"
+    tile_metadata_path.write_text(contents)
     tile_metadata = TileMetadata(tile_metadata_path)
     tile = tile_class(tile_metadata)
 

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -534,7 +534,9 @@ def test_tile_metadata_as_dict(tmp_path):
         (FilterTile, ".filter.json"),
     ],
 )
-def test_tile_validate_raises_value_error_when_content_is_empty(tmp_path, tile_class: Tile, extension: str) -> None:
+def test_tile_validate_raises_value_error_when_content_is_empty(
+    tmp_path, tile_class: type[Tile], extension: str
+) -> None:
     """Tile should have non-empty content"""
     tile_metadata_path = tmp_path / f"test{extension}"
     tile_metadata_path.touch()
@@ -554,7 +556,7 @@ def test_tile_validate_raises_value_error_when_content_is_empty(tmp_path, tile_c
     ],
 )
 def test_tile_validate_raises_value_error_when_name_contains_spaces(
-    tmp_path, tile_class: Tile, extension: str, contents: str
+    tmp_path, tile_class: type[Tile], extension: str, contents: str
 ) -> None:
     """A tile name cannot contain spaces"""
     tile_metadata_path = tmp_path / f"test with spaces{extension}"

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -514,6 +514,20 @@ def test_tile_validate_raises_value_error_when_content_is_empty(tmp_path, tile_c
         tile.validate()
 
 
+@pytest.mark.parametrize("tile_class", [Tile, QueryTile])
+def test_tile_validate_raises_value_error_when_name_contains_spaces(tmp_path, tile_class):
+    """A tile name cannot contain spaces"""
+    tile_metadata_path = tmp_path / "test with spaces.sql"
+    tile_metadata_path.write_text("SELECT 1")
+    tile = tile_class(TileMetadata(tile_metadata_path))
+
+    with pytest.raises(
+        ValueError,
+        match="Tile name should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_)",
+    ):
+        tile.validate()
+
+
 def test_markdown_tile_validate_raises_value_error_when_not_from_markdown_file(tmp_path):
     tile_metadata_path = tmp_path / "test.sql"
     tile_metadata_path.write_text("# Markdown")

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -550,11 +550,14 @@ def test_tile_validate_raises_value_error_when_name_contains_spaces(tmp_path, ti
     tile_metadata_path = tmp_path / "test with spaces.sql"
     tile_metadata_path.write_text("SELECT 1")
     tile = tile_class(TileMetadata(tile_metadata_path))
+    tile_metadata = TileMetadata(tile_metadata_path)
+    tile = tile_class(tile_metadata)
 
-    with pytest.raises(
-        ValueError,
-        match="Tile name should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_)",
-    ):
+    match = re.escape(
+        "Resource names should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_): "
+        + str(tile_metadata)
+    )
+    with pytest.raises(ValueError, match=match):
         tile.validate()
 
 

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -193,6 +193,20 @@ tiles:
     assert "Tile has empty content:" in str(e.value)
 
 
+def test_dashboard_metadata_validate_raises_value_error_for_non_alphanumeric_tile_id(tmp_path):
+    """A tile id can not contain special characters."""
+    (tmp_path / "@contains@special@characters.md").write_text("# Tile with invalid id")
+
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
+
+    match = re.escape(
+        "Resource names should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_): "
+        "TileMetadata<@contains@special@characters>"
+    )
+    with pytest.raises(ValueError, match=match):
+        dashboard_metadata.validate()
+
+
 def test_dashboard_metadata_validate_finds_duplicate_query_id(tmp_path):
     (tmp_path / "query.sql").write_text("SELECT 1")
     query_content = """-- --id query\nSELECT 1"""


### PR DESCRIPTION
Validate resource names to adhere to the ([new](https://github.com/databrickslabs/ucx/pull/3789)) naming convention:

Resource names should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_)

Resolves #355
Resolves #356