### PR TITLE
Explicitly install Python 3.12 before running fmt in CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
+      - name: Install Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          cache: 'pip'
+          cache-dependency-path: '**/pyproject.toml'
+          python-version: '3.12'
+
       - name: Format all files
         run: |
           pip install hatch==1.9.4

--- a/src/databricks/labs/lsql/backends.py
+++ b/src/databricks/labs/lsql/backends.py
@@ -154,7 +154,7 @@ class ExecutionBackend(SqlBackend):
         for i in range(0, len(rows), self._max_records_per_batch):
             batch = rows[i : i + self._max_records_per_batch]
             vals = "), (".join(self._row_to_sql(r, fields) for r in batch)
-            sql = f'INSERT {insert_modifier} {full_name} ({", ".join(field_names)}) VALUES ({vals})'
+            sql = f"INSERT {insert_modifier} {full_name} ({', '.join(field_names)}) VALUES ({vals})"
             self.execute(sql)
             # Only the first batch can truncate; subsequent batches append.
             insert_modifier = "INTO"

--- a/src/databricks/labs/lsql/lakeview/model.py
+++ b/src/databricks/labs/lsql/lakeview/model.py
@@ -79,7 +79,7 @@ class Scale(abc.ABC):
             return QuantitativeScale.from_dict(d)
         if d["type"] == "temporal":
             return TemporalScale.from_dict(d)
-        raise KeyError(f'unknown: type={d["type"]}')
+        raise KeyError(f"unknown: type={d['type']}")
 
 
 class WidgetSpec(abc.ABC):
@@ -127,7 +127,7 @@ class WidgetSpec(abc.ABC):
             return PivotSpec.from_dict(d)
         if d["version"] == 3 and d["widgetType"] == "scatter":
             return ScatterSpec.from_dict(d)
-        raise KeyError(f'unknown: version={d["version"]} widgetType={d["widgetType"]}')
+        raise KeyError(f"unknown: version={d['version']} widgetType={d['widgetType']}")
 
 
 class Alignment(Enum):

--- a/src/databricks/labs/lsql/lakeview/polymorphism.py
+++ b/src/databricks/labs/lsql/lakeview/polymorphism.py
@@ -69,14 +69,14 @@ def is_assignable(
         if isinstance(raw, type_ref):
             return True, None
         return False, _explain_why(type_ref, raw, path)
-    return False, f'{".".join(path)}: unknown: {raw}'
+    return False, f"{'.'.join(path)}: unknown: {raw}"
 
 
 # Function to explain why a value cannot be assigned to a type
 def _explain_why(type_ref: type, raw: Any, path: list[str]) -> str:
     if raw is None:
         raw = "value is missing"
-    return f'{".".join(path)}: not a {type_ref.__name__}: {raw}'
+    return f"{'.'.join(path)}: not a {type_ref.__name__}: {raw}"
 
 
 # Function to check if a value can be assigned to a generic alias
@@ -103,7 +103,7 @@ def _is_assignable_from_union(type_ref, raw, path, name_transform):
             return True, None
         if why_not:
             combo.append(why_not)
-    return False, f'{".".join(path)}: union: {" or ".join(combo)}'
+    return False, f"{'.'.join(path)}: union: {' or '.join(combo)}"
 
 
 # Function to check if a value can be assigned to a dataclass

--- a/src/databricks/labs/lsql/structs.py
+++ b/src/databricks/labs/lsql/structs.py
@@ -136,7 +136,7 @@ class StructInference:
         """Infers the primitive SQL type from the Python type. Raises StructInferError if the type is not supported."""
         if type_ref in self._PRIMITIVES:
             return PrimitiveType(self._PRIMITIVES[type_ref])
-        raise StructInferError(f'{".".join(path)}: unknown: {type_ref}')
+        raise StructInferError(f"{'.'.join(path)}: unknown: {type_ref}")
 
     def _infer_generic(self, type_ref: type, path: list[str]) -> SqlType:
         """Infers the SQL type from the generic Python type. Uses internal APIs to handle generic types."""
@@ -160,10 +160,10 @@ class StructInference:
         """Infers nullability from Optional[x] or `x | None` types."""
         type_args = get_args(type_ref)
         if len(type_args) > 2:
-            raise StructInferError(f'{".".join(path)}: union: too many variants: {type_args}')
+            raise StructInferError(f"{'.'.join(path)}: union: too many variants: {type_args}")
         first_type = self._infer(type_args[0], [*path, "(first)"])
         if type_args[1] is not type(None):
-            msg = f'{".".join(path)}.(second): not a NoneType: {type_args[1]}'
+            msg = f"{'.'.join(path)}.(second): not a NoneType: {type_args[1]}"
             raise StructInferError(msg)
         return NullableType(first_type)
 


### PR DESCRIPTION
Causing issues in #357, by explicitly choosing the Python version we know what Python version to verify locally with

Blocks #357