### PR TITLE
Remove the no cheat CI check

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,23 +60,3 @@ jobs:
 
       - name: Fail on differences
         run: git diff --exit-code
-
-  no-lint-disabled:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Verify no lint disabled in the new code
-        run: |
-          NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
-          echo "Code diff:"
-          echo "${NEW_CODE}"
-          CHEAT=$(echo "${NEW_CODE}" | grep '# pylint: disable' | grep -v "CHEAT" | wc -c)
-          echo "# cheats: ${CHEAT}"
-          if [ "${CHEAT}" -ne 0 ]; then
-            echo "Do not cheat the linter: ${CHEAT}"
-            exit 1
-          fi


### PR DESCRIPTION
It fails every time, e.g. https://github.com/databrickslabs/lsql/actions/runs/13569680322/job/37931216993.

Can be re-added later. In ucx we use [Python to verify we are not cheating pylint](https://github.com/databrickslabs/ucx/blob/ef45443480a0346efb99b67c2a99199ee4ffe1a4/tests/unit/no_cheat.py#L7)