### PR TITLE
Use greater and less than in sdk version constrain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "databricks-labs-blueprint[yaml]>=0.4.2",
-  "databricks-sdk~=0.38",
+  "databricks-sdk>=0.38.0,<1.0.0",
   "sqlglot>=22.3.1"
 ]
 


### PR DESCRIPTION
Use greater and less than in sdk version constrain because it is more clear