### PR TITLE
Let page name adhere to naming restrictions

### DIFF
--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -60,6 +60,7 @@ _INVALID_RESOURCE_NAME_MESSAGE = (
     "Resource names should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_)"
 )
 _VALID_RESOURCE_NAME_PATTERN = re.compile("^[A-Za-z0-9_-]+$")
+_CLEAN_RESOURCE_NAME_PATTERN = re.compile("[^A-Za-z0-9_-]+")
 
 
 def _is_valid_resource_name(name: str) -> bool:
@@ -68,6 +69,14 @@ def _is_valid_resource_name(name: str) -> bool:
     What is valid is defined by the Lakeview API, not by lsql.
     """
     return _VALID_RESOURCE_NAME_PATTERN.match(name) is not None
+
+
+def _clean_resource_name(name: str) -> str:
+    """Clean a resource name to become valid.
+
+    See :func:_is_valid_resource_name for the definition of a valid resource name.
+    """
+    return _CLEAN_RESOURCE_NAME_PATTERN.sub("_", name)
 
 
 class BaseHandler:
@@ -998,7 +1007,7 @@ class DashboardMetadata:
         datasets = self.get_datasets()
         layouts = self._get_layouts()
         page = Page(
-            name=self.display_name,
+            name=_clean_resource_name(self.display_name),
             display_name=self.display_name,
             layout=layouts,
         )

--- a/tests/integration/test_dashboards.py
+++ b/tests/integration/test_dashboards.py
@@ -160,7 +160,7 @@ def test_dashboard_deploys_dashboard_with_display_name(ws, make_dashboard, tmp_p
     dashboards = Dashboards(ws)
     sdk_dashboard = make_dashboard(display_name="Counter")
 
-    (tmp_path / "dashboard.yml").write_text("display_name: Counter")
+    (tmp_path / "dashboard.yml").write_text("display_name: 'My custom counter'")
     (tmp_path / "counter.sql").write_text("SELECT 102132 AS count")
     dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -659,6 +659,17 @@ def test_dashboard_metadata_as_lakeview_with_custom_first_page_name(tmp_path):
     assert page.display_name == "Custom"
 
 
+def test_dashboard_metadata_as_lakeview_cleans_page_name(tmp_path):
+    """The page name is not allowed to have special characters."""
+    (tmp_path / "dashboard.yml").write_text(f"display_name: 'name with spaces'")
+    dashboard_metadata = DashboardMetadata.from_path(tmp_path)
+
+    dashboard = dashboard_metadata.as_lakeview()
+
+    page = dashboard.pages[0]
+    assert " " not in page.name
+
+
 @pytest.mark.parametrize("dashboard_content", ["missing_display_name: true", "invalid:\nyml"])
 def test_dashboard_metadata_handles_invalid_dashboard_yml(tmp_path, dashboard_content):
     queries_path = tmp_path / "queries"


### PR DESCRIPTION
Let page names to adhere to the ([new](https://github.com/databrickslabs/ucx/pull/3789)) naming convention:

Resource names should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_)

Resolves #369