### PR TITLE
Add missing docstrings and clean up after fixing unique resource name constraints

### DIFF
--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -857,6 +857,7 @@ class TableTile(QueryTile):
 
     @property
     def position(self) -> Position:
+        """The position of the tile in the dashboard."""
         if self.metadata.width:
             width = self.metadata.width
         else:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -205,12 +205,17 @@ class QueryHandler(BaseHandler):
 
 
 class MarkdownHandler(BaseHandler):
-    """Handle Markdown files."""
+    """Handle Markdown files.
+
+    Sources:
+        https://frontmatter.codes/docs/markdown
+    """
 
     _FRONT_MATTER_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)
+    """The boundary to split the header from the content. A horizontal line marked with three dashes '---'."""
 
     def _parse_header(self, header: str) -> dict:
-        """Markdown configuration header is a YAML."""
+        """Parse the header as YAML."""
         _ = self
         return yaml.safe_load(header) or {}
 

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -309,7 +309,10 @@ class TileMetadata:
     """The height of the tile."""
 
     id: str = ""
-    """The unique id for the tile. Needs to adhere to :func:_is_valid_resource_name."""
+    """The unique id for the tile. 
+    
+    If not given, the stem of the path is used. Needs to adhere to :func:_is_valid_resource_name.
+    """
 
     title: str = ""
     """The tile title."""
@@ -327,6 +330,7 @@ class TileMetadata:
     """The raw API overrides for the widget."""
 
     def __post_init__(self):
+        """Handle the tile metadata id."""
         if not self.id:
             self.id = "" if self.path is None else self.path.stem
         self.id = _clean_resource_name(self.id)
@@ -373,16 +377,20 @@ class TileMetadata:
         return merged
 
     def is_markdown(self) -> bool:
+        """Check if the tile comes from a markdown file."""
         return self.path is not None and self.path.suffix == ".md"
 
     def is_query(self) -> bool:
+        """Check if the tile comes from a SQL file."""
         return self.path is not None and self.path.suffix == ".sql"
 
     def is_filter(self) -> bool:
+        """Check if the tile comes from a filter file."""
         return self.path is not None and self.path.name.endswith(".filter.yml")
 
     @property
     def handler(self) -> BaseHandler:
+        """Handler for parsing the tile file."""
         handler = BaseHandler
         if self.is_markdown():
             handler = MarkdownHandler
@@ -394,11 +402,13 @@ class TileMetadata:
 
     @classmethod
     def from_dict(cls, raw: dict) -> "TileMetadata":
+        """Create tile metadata from a dictionary."""
         path = raw.pop("path", None)
         path = Path(path) if path is not None else None
         return cls(path=path, **raw)
 
     def as_dict(self) -> dict:
+        """Convert tile metadata to a dictionary."""
         exclude_attributes = {
             "handler",  # Handler is inferred from file extension
             "path",  # Path is set explicitly below
@@ -423,6 +433,7 @@ class TileMetadata:
 
     @classmethod
     def from_path(cls, path: Path) -> "TileMetadata":
+        """Create tile metadata from a YAML file."""
         tile_metadata = cls(path=path)
         header = tile_metadata.handler.parse_header()
         header["path"] = path

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -607,6 +607,7 @@ class QueryTile(Tile):
         return formatted_query + ("\n" if has_eol else "")
 
     def _get_abstract_syntax_tree(self) -> sqlglot.Expression | None:
+        """Convert the contents to an abstract syntax tree."""
         try:
             return sqlglot.parse_one(self.content, dialect=_SQL_DIALECT)
         except sqlglot.ParseError as e:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -1105,6 +1105,7 @@ class DashboardMetadata:
 
     @classmethod
     def from_dict(cls, raw: dict) -> "DashboardMetadata":
+        """Create dashboard metadata from a dictionary."""
         display_name = raw["display_name"]  # Fail early if missing
         tiles, tiles_raw = [], raw.get("tiles", {})
         for tile_id, tile_raw in tiles_raw.items():
@@ -1128,6 +1129,7 @@ class DashboardMetadata:
         return cls(display_name=display_name, _tiles=tiles)
 
     def as_dict(self) -> dict:
+        """Convert dashboard metadata to a dictionary."""
         raw: dict = {"display_name": self.display_name}
         if self.tiles:
             raw["tiles"] = {tile.metadata.id: tile.metadata.as_dict() for tile in self.tiles}

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -857,7 +857,10 @@ class TableTile(QueryTile):
 
     @property
     def position(self) -> Position:
-        """The position of the tile in the dashboard."""
+        """The position of the tile in the dashboard.
+
+        If the width is not defined, we based the width on the number of fields while capping it with the maximum width.
+        """
         if self.metadata.width:
             width = self.metadata.width
         else:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -819,7 +819,10 @@ class QueryTile(Tile):
 
 @dataclass
 class TableTile(QueryTile):
+    """A tile based on a sql query creating a table widget."""
+
     _position: Position = dataclasses.field(default_factory=lambda: Position(0, 0, 3, 6))
+    """The position of the tile in the dashboard. Hidden stateful attribute updated by the tiling logic."""
 
     @property
     def position(self) -> Position:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -967,9 +967,11 @@ class FilterTile(Tile):
 class DashboardMetadata:
     """The metadata defining a lakeview dashboard"""
 
-    display_name: str  # The dashboard display name
+    display_name: str
+    """The dashboard display name"""
 
-    _tiles: list[Tile] = dataclasses.field(default_factory=list)  # The dashboard tiles
+    _tiles: list[Tile] = dataclasses.field(default_factory=list)
+    """The dashboard tiles. Hidden attribute as this contains the unordered tiles."""
 
     @property
     def tiles(self) -> list[Tile]:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -919,6 +919,7 @@ class FilterTile(Tile):
         yield layout
 
     def _create_widget(self, datasets: list[Dataset]) -> Widget:
+        """Create the filter widget."""
         dataset_columns = self._get_dataset_columns(datasets)
         # This method is called during get layouts.
         # Metadata validation is done before getting the layouts.
@@ -964,6 +965,7 @@ class FilterTile(Tile):
         dataset_columns: set[tuple[str, str]],
         spec_type,
     ) -> Widget:
+        """Create the filter widget."""
         frame = self._create_widget_frame()
         control_encodings, queries = self._generate_filter_encodings_and_queries(dataset_columns)
         control_encoding_map = ControlEncodingMap(control_encodings)
@@ -972,6 +974,7 @@ class FilterTile(Tile):
         return widget
 
     def _create_widget_frame(self) -> WidgetFrameSpec:
+        """Create the widget frame."""
         return WidgetFrameSpec(
             title=self.metadata.title,
             show_title=len(self.metadata.title) > 0,
@@ -982,6 +985,7 @@ class FilterTile(Tile):
     def _generate_filter_encodings_and_queries(
         self, dataset_columns: set[tuple[str, str]]
     ) -> tuple[list[ControlEncoding], list[NamedQuery]]:
+        """Generate the filter encodings and queries from the dataset columns."""
         encodings: list[ControlEncoding] = []
         queries = []
 

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -283,10 +283,8 @@ class TileMetadata:
 
     def __post_init__(self):
         if not self.id:
-            path_stem = "" if self.path is None else self.path.stem
-            if self.is_filter():  # To adhere to :func:_is_valid_resource_name
-                path_stem = path_stem.replace(".filter", "_filter")
-            self.id = path_stem
+            self.id = "" if self.path is None else self.path.stem
+        self.id = _clean_resource_name(self.id)
 
     def validate(self) -> None:
         """Validate the tile metadata.

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -278,15 +278,34 @@ class TileMetadata:
     """The metadata defining a :class:Tile"""
 
     path: Path | None = None
+    """The path to the tile file."""
+
     order: int | None = None
+    """The order of the tile."""
+
     width: int = 0
+    """The width of the tile."""
+
     height: int = 0
+    """The height of the tile."""
+
     id: str = ""
+    """The unique id for the tile. Needs to adhere to :func:_is_valid_resource_name."""
+
     title: str = ""
+    """The tile title."""
+
     description: str = ""
+    """The tile description."""
+
     widget_type: WidgetType = WidgetType.AUTO
+    """The widget type. If AUTO, the widget type is inferred from the query."""
+
     filters: list[str] = dataclasses.field(default_factory=list)
+    """The filters applied to the tile."""
+
     overrides: dict = dataclasses.field(default_factory=dict)
+    """The raw API overrides for the widget."""
 
     def __post_init__(self):
         if not self.id:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -89,6 +89,8 @@ def _clean_resource_name(name: str) -> str:
 class BaseHandler:
     """Base file handler.
 
+    A handler is responsible for parsing the header of a file and splitting the header from the contents.
+
     Handlers are based on a Python implementation for FrontMatter.
 
     Sources:
@@ -101,6 +103,7 @@ class BaseHandler:
 
     @property
     def _content(self) -> str:
+        """The contents of the file."""
         if self._path is None:
             return ""
         return self._path.read_text()
@@ -111,6 +114,7 @@ class BaseHandler:
         return self._parse_header(header)
 
     def _parse_header(self, header: str) -> dict:
+        """Parse the header of the file. Hidden method to be overwritten by subclasses."""
         _ = self, header
         return {}
 

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -418,12 +418,17 @@ class Tile:
     """A dashboard tile."""
 
     metadata: TileMetadata
+    """The tile metadata."""
 
     _content: str = ""
+    """The contents of the tile file. Hidden attribute that functions as a cache to read contents once."""
+
     _position: Position = dataclasses.field(default_factory=lambda: Position(0, 0, 0, 0))
+    """The position of the tile in the dashboard. Hidden stateful attribute updated by the tiling logic."""
 
     @property
     def content(self) -> str:
+        """The content of the tile file."""
         if len(self._content) == 0:
             _, content = self.metadata.handler.split()
             self._content = content
@@ -431,6 +436,7 @@ class Tile:
 
     @property
     def position(self) -> Position:
+        """The position of the tile in the dashboard."""
         width = self.metadata.width or self._position.width
         height = self.metadata.height or self._position.height
         return Position(self._position.x, self._position.y, width, height)

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -237,6 +237,7 @@ class FilterHandler(BaseHandler):
     """Handle filter files."""
 
     def _parse_header(self, header: str) -> dict:
+        """Parse the header as YAML."""
         if not header:
             return {}
         metadata = yaml.safe_load(header) or {}
@@ -255,6 +256,10 @@ class FilterHandler(BaseHandler):
         return metadata
 
     def split(self) -> tuple[str, str]:
+        """Split the header from the contents.
+
+        The (current) filter definition only contains a header.
+        """
         trimmed_content = self._content.strip()
         return trimmed_content, ""
 

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -133,6 +133,7 @@ class QueryHandler(BaseHandler):
 
     @staticmethod
     def _get_arguments_parser() -> ArgumentParser:
+        """Get the argument parser to parse the query header with."""
         parser = ArgumentParser("TileMetadata", add_help=False, exit_on_error=False)
         parser.add_argument("--id", type=str)
         parser.add_argument("-o", "--order", type=int)
@@ -168,7 +169,7 @@ class QueryHandler(BaseHandler):
         return parser
 
     def _parse_header(self, header: str) -> dict:
-        """Header is an argparse string."""
+        """Parse header as an argparse string."""
         header_split = shlex.split(header)
         parser = self._get_arguments_parser()
         try:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -266,7 +266,10 @@ class FilterHandler(BaseHandler):
 
 @unique
 class WidgetType(str, Enum):
-    """The query widget type"""
+    """The query widget type.
+
+    A mapping from lsql supported widget types to Lakeview widget specs.
+    """
 
     AUTO = "AUTO"
     TABLE = "TABLE"
@@ -276,6 +279,7 @@ class WidgetType(str, Enum):
     DROPDOWN = "DROPDOWN"
 
     def as_widget_spec(self) -> type[WidgetSpec]:
+        """Convert a widget type to a widget spec."""
         widget_spec_mapping: dict[str, type[WidgetSpec]] = {
             "TABLE": TableV1Spec,
             "COUNTER": CounterSpec,

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -877,6 +877,7 @@ class CounterTile(QueryTile):
 
     @staticmethod
     def _get_query_widget_spec(fields: list[Field], *, frame: WidgetFrameSpec | None = None) -> CounterSpec:
+        """Get query widget spec."""
         counter_encodings = CounterFieldEncoding(field_name=fields[0].name, display_name=fields[0].name)
         spec = CounterSpec(CounterEncodingMap(value=counter_encodings), frame=frame)
         return spec

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -515,8 +515,13 @@ class QueryTile(Tile):
     """A tile based on a sql query."""
 
     query_transformer: Callable[[sqlglot.Expression], sqlglot.Expression] | None = None
+    """A sqlglot transformer to apply to the query before rendering the tile.
+    
+    Useful for templating SQL queries, like a dynamic catalor or database name.
+    """
 
     _FILTER_HEIGHT = 1
+    """The height of filter widgets. Hidden attribute as it is a static value."""
 
     def validate(self) -> None:
         """Validate the tile

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -76,7 +76,7 @@ def _clean_resource_name(name: str) -> str:
 
     See :func:_is_valid_resource_name for the definition of a valid resource name.
     """
-    return _CLEAN_RESOURCE_NAME_PATTERN.sub("_", name)
+    return _CLEAN_RESOURCE_NAME_PATTERN.sub("", name)
 
 
 class BaseHandler:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -1,3 +1,10 @@
+"""
+Deploy Lakeview dashboards from code.
+
+Docs:
+../../../../docs/dashboards.md
+"""
+
 import argparse
 import collections
 import csv

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -838,7 +838,10 @@ class TableTile(QueryTile):
 
 @dataclass
 class CounterTile(QueryTile):
+    """A tile based on a sql query creating a counter widget."""
+
     _position: Position = dataclasses.field(default_factory=lambda: Position(0, 0, 1, 3))
+    """The position of the tile in the dashboard. Hidden stateful attribute updated by the tiling logic."""
 
     @staticmethod
     def _get_query_widget_spec(fields: list[Field], *, frame: WidgetFrameSpec | None = None) -> CounterSpec:

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -1204,16 +1204,20 @@ class DashboardMetadata:
 
 
 class Dashboards:
+    """The API for Lakeview dashboards."""
+
     def __init__(self, ws: WorkspaceClient):
         self._ws = ws
 
     def get_dashboard(self, dashboard_path: str) -> Dashboard:
+        """Get a Lakeview dashboard."""
         with self._ws.workspace.download(dashboard_path, format=ExportFormat.SOURCE) as f:
             raw = f.read().decode("utf-8")
             as_dict = json.loads(raw)
             return Dashboard.from_dict(as_dict)
 
     def save_to_folder(self, dashboard: Dashboard, local_path: Path) -> Dashboard:
+        """Save the lakeview dashboard to a local folder."""
         local_path.mkdir(parents=True, exist_ok=True)
         dashboard = self._with_better_names(dashboard)
         for dataset in dashboard.datasets:
@@ -1281,6 +1285,7 @@ class Dashboards:
         return self._replace_names(dashboard, better_names)
 
     def _replace_names(self, node: T, better_names: dict[str, str]) -> T:
+        """Replace names with human-readable names."""
         # walk every dataclass instance recursively and replace names
         if dataclasses.is_dataclass(node):
             for field in dataclasses.fields(node):

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -494,7 +494,10 @@ class Tile:
 
 @dataclass
 class MarkdownTile(Tile):
+    """A tile representing a markdown file."""
+
     _position: Position = dataclasses.field(default_factory=lambda: Position(0, 0, _MAXIMUM_DASHBOARD_WIDTH, 3))
+    """The position of the tile in the dashboard. Hidden stateful attribute updated by the tiling logic."""
 
     def validate(self) -> None:
         """Validate the tile

--- a/src/databricks/labs/lsql/dashboards.py
+++ b/src/databricks/labs/lsql/dashboards.py
@@ -852,7 +852,10 @@ class CounterTile(QueryTile):
 
 @dataclass
 class FilterTile(Tile):
+    """A tile based on a filter file creating a filter widget."""
+
     _position: Position = dataclasses.field(default_factory=lambda: Position(0, 0, 3, 2))
+    """The position of the tile in the dashboard. Hidden stateful attribute updated by the tiling logic."""
 
     def validate(self) -> None:
         """Validate the tile

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -198,12 +198,8 @@ def test_dashboard_metadata_validate_does_not_raise_value_error_for_non_alphanum
 
     dashboard_metadata = DashboardMetadata.from_path(tmp_path)
 
-    try:
-        dashboard_metadata.validate()
-    except ValueError:
-        assert False, "Tile id with special characters is not cleaned up"
-    else:
-        assert True, "Tile id with special characters is cleaned up"
+    dashboard_metadata.validate()
+    assert True, "Tile id with special characters is cleaned up"
 
 
 def test_dashboard_metadata_validate_finds_duplicate_query_id(tmp_path):
@@ -240,12 +236,8 @@ def test_tile_metadata_validate_not_raises_value_error_for_non_alphanumeric_id()
     """The tile metadata id should not contain special characters, but we clean it up in _post_init"""
     tile_metadata = TileMetadata(id=")contains#special@characters")
 
-    try:
-        tile_metadata.validate()
-    except ValueError:
-        assert False, "Tile id with special characters is not cleaned up"
-    else:
-        assert True, "Tile id with special characters is cleaned up"
+    tile_metadata.validate()
+    assert True, "Tile id with special characters is cleaned up"
 
 
 def test_tile_metadata_validate_raises_value_error_for_non_alphanumeric_id() -> None:


### PR DESCRIPTION
### Changes

Add missing docstrings and clean tile metadata id using the function introduced in #370