### PR TITLE
Update the minimum version of `databricks-labs-pytester` to 0.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "coverage[toml]>=6.5",
     "pytest",
     "pylint",
-    "databricks-labs-pytester>=0.5.0",
+    "databricks-labs-pytester>=0.7.2",
     "pytest-xdist",
     "pytest-cov>=4.0.0,<5.0.0",
     "pytest-mock>=3.0.0,<4.0.0",


### PR DESCRIPTION
The [just released](https://github.com/databrickslabs/pytester/releases/tag/v0.7.2) version of `pytester` includes a fix for a breaking change that was introduced by Databricks SDK 0.51: older versions of pytester will fail to import if the new Databricks SDK is present.

This PR updates the test dependencies for this project to require that version or later. This is mainly an informational change: it doesn't affect normal installs of `lsql`, nor does it affect fresh installs of this project for development because the latest version will be picked up.