### PR TITLE
Disable downstream `ucx` check

### DIFF
--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -30,7 +30,12 @@ jobs:
       fail-fast: false
       matrix:
         downstream:
-          - name: ucx
+          # Disabled for UCX as of the 0.17 release:
+          #  - UCX depends on <0.17 so the checks are moot. (And we know they will fail.)
+          #  - The downstream test also force-installs a version of the Databricks SDK that causes many UCX tests to
+          #    fail.
+          # Both will need to be addressed before this can (and should) be enabled again.
+          #- name: ucx
           - name: remorph
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
For the 0.17 release we need to disable the downstream UCX check:

 - The checks are moot, because UCX pins to <0.17;
 - The way the checks are implemented reveals an issue that many UCX unit tests have with the latest version of the Databricks SDK.

Both will need to be addressed in UCX before this check can be enabled again.